### PR TITLE
Rename project to LocalAI

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=quay.io/go-skynet/llama-cli
+          DOCKER_IMAGE=quay.io/go-skynet/local-ai
           VERSION=master
           SHORTREF=${GITHUB_SHA::8}
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 go-llama
 go-gpt4all-j
 
-# llama-cli build binary
-llama-cli
+# LocalAI build binary
+LocalAI
+local-ai
 
 # Ignore models
 models/*.bin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,5 @@
 # Make sure to check the documentation at http://goreleaser.com
-project_name: llama-cli
+project_name: local-ai
 builds:
   - ldflags:
       - -w -s

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ ARG BUILD_TYPE=
 RUN make build${BUILD_TYPE}
 
 FROM debian:$DEBIAN_VERSION
-COPY --from=builder /build/llama-cli /usr/bin/llama-cli
-ENTRYPOINT [ "/usr/bin/llama-cli" ]
+COPY --from=builder /build/local-ai /usr/bin/local-ai
+ENTRYPOINT [ "/usr/bin/local-ai" ]

--- a/Earthfile
+++ b/Earthfile
@@ -2,4 +2,4 @@ VERSION 0.7
 
 build:
     FROM DOCKERFILE -f Dockerfile .
-    SAVE ARTIFACT /usr/bin/llama-cli AS LOCAL llama-cli
+    SAVE ARTIFACT /usr/bin/local-ai AS LOCAL local-ai

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOCMD=go
 GOTEST=$(GOCMD) test
 GOVET=$(GOCMD) vet
-BINARY_NAME=llama-cli
+BINARY_NAME=local-ai
 GOLLAMA_VERSION?=llama.cpp-5ecff35
 
 GREEN  := $(shell tput -Txterm setaf 2)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-## :camel: llama-cli
+## :camel: LocalAI
 
+> :warning: This project has been renamed from `llama-cli` to `LocalAI` to reflect the fact that we are focusing on a fast drop-in OpenAI API rather on the CLI interface. We think that there are already many projects that can be used as a CLI interface already, for instance  [llama.cpp](https://github.com/ggerganov/llama.cpp) and [gpt4all](https://github.com/nomic-ai/gpt4all). If you are were using `llama-cli` for CLI interactions and want to keep using it, use older versions or please open up an issue - contributions are welcome!
 
-llama-cli is a straightforward, drop-in replacement API compatible with OpenAI for local CPU inferencing, based on [llama.cpp](https://github.com/ggerganov/llama.cpp), [gpt4all](https://github.com/nomic-ai/gpt4all) and [ggml](https://github.com/ggerganov/ggml), including support GPT4ALL-J which is Apache 2.0 Licensed and can be used for commercial purposes.
+LocalAI is a straightforward, drop-in replacement API compatible with OpenAI for local CPU inferencing, based on [llama.cpp](https://github.com/ggerganov/llama.cpp), [gpt4all](https://github.com/nomic-ai/gpt4all) and [ggml](https://github.com/ggerganov/ggml), including support GPT4ALL-J which is Apache 2.0 Licensed and can be used for commercial purposes.
 
 - OpenAI compatible API
 - Supports multiple-models
@@ -18,12 +19,15 @@ Note: You might need to convert older models to the new format, see [here](https
 
 ## Usage
 
-The easiest way to run llama-cli is by using `docker-compose`:
+> `LocalAI` comes by default as a container image. You can check out all the available images with corresponding tags [here](https://quay.io/repository/go-skynet/local-ai?tab=tags&tag=latest).
+
+The easiest way to run LocalAI is by using `docker-compose`:
 
 ```bash
 
-git clone https://github.com/go-skynet/llama-cli
-cd llama-cli
+git clone https://github.com/go-skynet/LocalAI
+
+cd LocalAI
 
 # copy your models to models/
 cp your-model.bin models/
@@ -45,8 +49,11 @@ curl http://localhost:8080/v1/completions -H "Content-Type: application/json" -d
    }'
 ```
 
-Note: The API doesn't inject a default prompt for talking to the model, while the CLI does. You have to use a prompt similar to what's described in the standford-alpaca docs: https://github.com/tatsu-lab/stanford_alpaca#data-release.
+## Prompt templates 
 
+The API doesn't inject a default prompt for talking to the model. You have to use a prompt similar to what's described in the standford-alpaca docs: https://github.com/tatsu-lab/stanford_alpaca#data-release.
+
+<details>
 You can use a default template for every model present in your model path, by creating a corresponding file with the `.tmpl` suffix next to your model. For instance, if the model is called `foo.bin`, you can create a sibiling file, `foo.bin.tmpl` which will be used as a default prompt, for instance this can be used with alpaca:
 
 ```
@@ -58,70 +65,19 @@ Below is an instruction that describes a task. Write a response that appropriate
 ### Response:
 ```
 
-See the [prompt-templates](https://github.com/go-skynet/llama-cli/tree/master/prompt-templates) directory in this repository for templates for most popular models.
+See the [prompt-templates](https://github.com/go-skynet/LocalAI/tree/master/prompt-templates) directory in this repository for templates for most popular models.
 
-## Container images
-
-`llama-cli` comes by default as a container image. You can check out all the available images with corresponding tags [here](https://quay.io/repository/go-skynet/llama-cli?tab=tags&tag=latest)
-
-To begin, run:
-
-```
-docker run -ti --rm quay.io/go-skynet/llama-cli:latest  --instruction "What's an alpaca?" --topk 10000 --model ...
-```
-
-Where `--model` is the path of the model you want to use. 
-
-Note: you need to mount a volume to the docker container in order to load a model, for instance:
-
-```
-# assuming your model is in /path/to/your/models/foo.bin
-docker run -v /path/to/your/models:/models -ti --rm quay.io/go-skynet/llama-cli:latest  --instruction "What's an alpaca?" --topk 10000 --model /models/foo.bin
-```
-
-You will receive a response like the following:
-
-```
-An alpaca is a member of the South American Camelid family, which includes the llama, guanaco and vicuña. It is a domesticated species that originates from the Andes mountain range in South America. Alpacas are used in the textile industry for their fleece, which is much softer than wool. Alpacas are also used for meat, milk, and fiber.
-```
-
-## Basic usage
-
-To use llama-cli, specify a pre-trained GPT-based model, an input text, and an instruction for text generation. llama-cli takes the following arguments when running from the CLI:
-
-```
-llama-cli --model <model_path> --instruction <instruction> [--input <input>] [--template <template_path>] [--tokens <num_tokens>] [--threads <num_threads>] [--temperature <temperature>] [--topp <top_p>] [--topk <top_k>]
-```
-
-| Parameter    | Environment Variable | Default Value | Description                            |
-| ------------ | -------------------- | ------------- | -------------------------------------- |
-| template     | TEMPLATE             |               | A file containing a template for output formatting (optional).  |
-| instruction  | INSTRUCTION          |               | Input prompt text or instruction. "-" for STDIN.   |
-| input        | INPUT                | -             | Path to text or "-" for STDIN.                    |
-| model        | MODEL           |               | The path to the pre-trained GPT-based model.      |
-| tokens       | TOKENS               | 128           | The maximum number of tokens to generate. |
-| threads      | THREADS              | NumCPU()      | The number of threads to use for text generation. |
-| temperature  | TEMPERATURE          | 0.95          | Sampling temperature for model output. ( values between `0.1` and `1.0` )  |
-| top_p        | TOP_P                | 0.85          | The cumulative probability for top-p sampling. |
-| top_k        | TOP_K                | 20            | The number of top-k tokens to consider for text generation.  |
-| context-size | CONTEXT_SIZE         | 512           | Default token context size. |
-
-Here's an example of using `llama-cli`:
-
-```
-llama-cli --model ~/ggml-alpaca-7b-q4.bin --instruction "What's an alpaca?"
-```
-
-This will generate text based on the given model and instruction.
+</details>
 
 ## API
 
-`llama-cli` also provides an API for running text generation as a service. The models once loaded the first time will be kept in memory.
+`LocalAI` provides an API for running text generation as a service, that follows the OpenAI reference and can be used as a drop-in. The models once loaded the first time will be kept in memory.
 
+<details>
 Example of starting the API with `docker`:
 
 ```bash
-docker run -p 8080:8080 -ti --rm quay.io/go-skynet/llama-cli:latest api --models-path /path/to/models --context-size 700 --threads 4
+docker run -p 8080:8080 -ti --rm quay.io/go-skynet/local-api:latest --models-path /path/to/models --context-size 700 --threads 4
 ```
 
 And you'll see:
@@ -136,15 +92,15 @@ And you'll see:
 └───────────────────────────────────────────────────┘ 
 ```
 
-Note: Models have to end up with `.bin`.
+Note: Models have to end up with `.bin` so can be listed by the `/models` endpoint.
 
 You can control the API server options with command line arguments:
 
 ```
-llama-cli api --models-path <model_path> [--address <address>] [--threads <num_threads>]
+local-api --models-path <model_path> [--address <address>] [--threads <num_threads>]
 ```
 
-The API takes takes the following:
+The API takes takes the following parameters:
 
 | Parameter    | Environment Variable | Default Value | Description                            |
 | ------------ | -------------------- | ------------- | -------------------------------------- |
@@ -154,6 +110,8 @@ The API takes takes the following:
 | context-size | CONTEXT_SIZE         | 512           | Default token context size. |
 
 Once the server is running, you can start making requests to it using HTTP, using the OpenAI API. 
+
+</details>
 
 ### Supported OpenAI API endpoints
 
@@ -212,41 +170,34 @@ python 828bddec6162a023114ce19146cb2b82/gistfile1.txt models tokenizer.model
 
 ### Windows compatibility
 
-It should work, however you need to make sure you give enough resources to the container. See https://github.com/go-skynet/llama-cli/issues/2
+It should work, however you need to make sure you give enough resources to the container. See https://github.com/go-skynet/LocalAI/issues/2
 
 ### Kubernetes
 
-You can run the API directly in Kubernetes:
-
-```bash
-kubectl apply -f https://raw.githubusercontent.com/go-skynet/llama-cli/master/kubernetes/deployment.yaml
-```
+You can run the API in Kubernetes, see an example deployment in [kubernetes](https://github.com/go-skynet/LocalAI/tree/master/kubernetes)
 
 ### Build locally
 
 Pre-built images might fit well for most of the modern hardware, however you can and might need to build the images manually.
 
-In order to build the `llama-cli` container image locally you can use `docker`:
+In order to build the `LocalAI` container image locally you can use `docker`:
 
 ```
-# build the image as "alpaca-image"
-docker build -t llama-cli .
-docker run llama-cli --instruction "What's an alpaca?"
+# build the image
+docker build -t LocalAI .
+docker run LocalAI
 ```
 
-Or build the binary with:
+Or build the binary with `make`:
 
 ```
-# build the image as "alpaca-image"
-docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock --rm -t -v "$(pwd)":/workspace -v earthly-tmp:/tmp/earthly:rw earthly/earthly:v0.7.2 +build
-# run the binary
-./llama-cli --instruction "What's an alpaca?"
+make build
 ```
 
 ## Short-term roadmap
 
-- [x] Mimic OpenAI API (https://github.com/go-skynet/llama-cli/issues/10)
-- Binary releases (https://github.com/go-skynet/llama-cli/issues/6)
+- [x] Mimic OpenAI API (https://github.com/go-skynet/LocalAI/issues/10)
+- Binary releases (https://github.com/go-skynet/LocalAI/issues/6)
 - Upstream our golang bindings to llama.cpp (https://github.com/ggerganov/llama.cpp/issues/351)
 - [x] Multi-model support
 - Have a webUI!

--- a/api/api.go
+++ b/api/api.go
@@ -5,8 +5,7 @@ import (
 	"strings"
 	"sync"
 
-	model "github.com/go-skynet/llama-cli/pkg/model"
-
+	model "github.com/go-skynet/LocalAI/pkg/model"
 	gptj "github.com/go-skynet/go-gpt4all-j.cpp"
 	llama "github.com/go-skynet/go-llama.cpp"
 	"github.com/gofiber/fiber/v2"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,18 +1,8 @@
 version: '3.6'
 
 services:
-
-  # chatgpt:
-  #   image: ghcr.io/mckaywrigley/chatbot-ui:main
-  #   # platform: linux/amd64
-  #   ports:
-  #     - 3000:3000
-  #   environment:
-  #     - 'OPENAI_API_KEY=sk-000000000000000'
-  #     - 'OPENAI_API_HOST=http://api:8080'
-
   api:
-    image: quay.io/go-skynet/llama-cli:latest
+    image: quay.io/go-skynet/local-ai:latest
     build:
       context: .
       dockerfile: Dockerfile
@@ -26,5 +16,3 @@ services:
       - THREADS=$THREADS
     volumes:
       - ./models:/models:cached
-    command: api
-    

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-skynet/llama-cli
+module github.com/go-skynet/LocalAI
 
 go 1.19
 

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -23,9 +23,7 @@ spec:
     spec:
       containers:
         - name: llama
-          args:
-          - api
-          image: quay.io/go-skynet/llama-cli:latest
+          image: quay.io/go-skynet/local-ai:latest
 ---
 apiVersion: v1
 kind: Service

--- a/main.go
+++ b/main.go
@@ -1,230 +1,76 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
-	"text/template"
 
-	llama "github.com/go-skynet/go-llama.cpp"
-	api "github.com/go-skynet/llama-cli/api"
-	model "github.com/go-skynet/llama-cli/pkg/model"
+	api "github.com/go-skynet/LocalAI/api"
+	model "github.com/go-skynet/LocalAI/pkg/model"
 
 	"github.com/urfave/cli/v2"
 )
 
-// Define the template string
-var emptyInput string = `Below is an instruction that describes a task. Write a response that appropriately completes the request.
-
-### Instruction:
-{{.Instruction}}
-
-### Response:`
-
-var nonEmptyInput string = `Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
-
-### Instruction:
-{{.Instruction}}
-
-### Input:
-{{.Input}}
-
-### Response:
-`
-
-func templateString(t string, in interface{}) (string, error) {
-	// Parse the template
-	tmpl, err := template.New("prompt").Parse(t)
-	if err != nil {
-		return "", err
-	}
-
-	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, in)
-	if err != nil {
-		return "", err
-	}
-	return buf.String(), nil
-}
-
-var modelFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:    "model",
-		EnvVars: []string{"MODEL"},
-	},
-	&cli.IntFlag{
-		Name:    "tokens",
-		EnvVars: []string{"TOKENS"},
-		Value:   128,
-	},
-	&cli.IntFlag{
-		Name:    "context-size",
-		EnvVars: []string{"CONTEXT_SIZE"},
-		Value:   512,
-	},
-	&cli.IntFlag{
-		Name:    "threads",
-		EnvVars: []string{"THREADS"},
-		Value:   runtime.NumCPU(),
-	},
-	&cli.Float64Flag{
-		Name:    "temperature",
-		EnvVars: []string{"TEMPERATURE"},
-		Value:   0.95,
-	},
-	&cli.Float64Flag{
-		Name:    "topp",
-		EnvVars: []string{"TOP_P"},
-		Value:   0.85,
-	},
-	&cli.IntFlag{
-		Name:    "topk",
-		EnvVars: []string{"TOP_K"},
-		Value:   20,
-	},
-}
-
 func main() {
+	path, err := os.Getwd()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	app := &cli.App{
-		Name:    "llama-cli",
-		Version: "0.1",
-		Usage:   "llama-cli --model ... --instruction 'What is an alpaca?'",
-		Flags: append(modelFlags,
-			&cli.StringFlag{
-				Name:    "template",
-				EnvVars: []string{"TEMPLATE"},
+		Name:  "LocalAI",
+		Usage: "OpenAI compatible API for running LLaMA/GPT models locally on CPU with consumer grade hardware.",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:    "f16",
+				EnvVars: []string{"F16"},
+			},
+			&cli.IntFlag{
+				Name:        "threads",
+				DefaultText: "Number of threads used for parallel computation. Usage of the number of physical cores in the system is suggested.",
+				EnvVars:     []string{"THREADS"},
+				Value:       runtime.NumCPU(),
 			},
 			&cli.StringFlag{
-				Name:    "instruction",
-				EnvVars: []string{"INSTRUCTION"},
+				Name:        "models-path",
+				DefaultText: "Path containing models used for inferencing",
+				EnvVars:     []string{"MODELS_PATH"},
+				Value:       path,
 			},
 			&cli.StringFlag{
-				Name:    "input",
-				EnvVars: []string{"INPUT"},
-			}),
-		Description: `Run llama.cpp inference`,
-		UsageText: `
-llama-cli --model ~/ggml-alpaca-7b-q4.bin --instruction "What's an alpaca?"
-
-	An Alpaca (Vicugna pacos) is a domesticated species of South American camelid, related to llamas and originally from Peru but now found throughout much of Andean region. They are bred for their fleeces which can be spun into wool or knitted items such as hats, sweaters, blankets etc
-		
-echo "An Alpaca (Vicugna pacos) is a domesticated species of South American camelid, related to llamas and originally from Peru but now found throughout much of Andean region. They are bred for their fleeces which can be spun into wool or knitted items such as hats, sweaters, blankets etc" | llama-cli --model ~/ggml-alpaca-7b-q4.bin --instruction "Proofread, improving clarity and flow" --input "-"
-
-	An Alpaca (Vicugna pacos) is a domesticated species from South America that's related to llamas. Originating in Peru but now found throughout the Andean region, they are bred for their fleeces which can be spun into wool or knitted items such as hats and sweaters—blankets too!
-`,
-		Copyright: "go-skynet authors",
-		Commands: []*cli.Command{
-			{
-
-				Name: "api",
-				Flags: []cli.Flag{
-					&cli.BoolFlag{
-						Name:    "f16",
-						EnvVars: []string{"F16"},
-					},
-					&cli.IntFlag{
-						Name:    "threads",
-						EnvVars: []string{"THREADS"},
-						Value:   runtime.NumCPU(),
-					},
-					&cli.StringFlag{
-						Name:    "models-path",
-						EnvVars: []string{"MODELS_PATH"},
-					},
-					&cli.StringFlag{
-						Name:    "address",
-						EnvVars: []string{"ADDRESS"},
-						Value:   ":8080",
-					},
-					&cli.IntFlag{
-						Name:    "context-size",
-						EnvVars: []string{"CONTEXT_SIZE"},
-						Value:   512,
-					},
-				},
-				Action: func(ctx *cli.Context) error {
-					return api.Start(model.NewModelLoader(ctx.String("models-path")), ctx.String("address"), ctx.Int("threads"), ctx.Int("context-size"), ctx.Bool("f16"))
-				},
+				Name:        "address",
+				DefaultText: "Bind address for the API server.",
+				EnvVars:     []string{"ADDRESS"},
+				Value:       ":8080",
+			},
+			&cli.IntFlag{
+				Name:        "context-size",
+				DefaultText: "Default context size of the model",
+				EnvVars:     []string{"CONTEXT_SIZE"},
+				Value:       512,
 			},
 		},
+		Description: `
+LocalAI is a drop-in replacement OpenAI API which runs inference locally.
+
+Some of the models compatible are:
+- Vicuna
+- Koala
+- GPT4ALL
+- GPT4ALL-J
+- Alpaca
+
+It uses llama.cpp and gpt4all as backend, supporting all the models supported by both.
+`,
+		UsageText: `local-ai [options]`,
+		Copyright: "go-skynet authors",
 		Action: func(ctx *cli.Context) error {
-
-			instruction := ctx.String("instruction")
-			input := ctx.String("input")
-			templ := ctx.String("template")
-
-			promptTemplate := ""
-
-			if input != "" {
-				promptTemplate = nonEmptyInput
-			} else {
-				promptTemplate = emptyInput
-			}
-
-			if templ != "" {
-				dat, err := os.ReadFile(templ)
-				if err != nil {
-					fmt.Printf("Failed reading file: %s", err.Error())
-					os.Exit(1)
-				}
-				promptTemplate = string(dat)
-			}
-
-			if instruction == "-" {
-				dat, err := ioutil.ReadAll(os.Stdin)
-				if err != nil {
-					fmt.Printf("reading stdin failed: %s", err)
-					os.Exit(1)
-				}
-				instruction = string(dat)
-			}
-
-			if input == "-" {
-				dat, err := ioutil.ReadAll(os.Stdin)
-				if err != nil {
-					fmt.Printf("reading stdin failed: %s", err)
-					os.Exit(1)
-				}
-				input = string(dat)
-			}
-
-			str, err := templateString(promptTemplate, struct {
-				Instruction string
-				Input       string
-			}{Instruction: instruction, Input: input})
-
-			if err != nil {
-				fmt.Println("Templating the input failed:", err.Error())
-				os.Exit(1)
-			}
-
-			opts := []llama.ModelOption{llama.SetContext(ctx.Int("context-size"))}
-			l, err := llama.New(ctx.String("model"), opts...)
-			if err != nil {
-				fmt.Println("Loading the model failed:", err.Error())
-				os.Exit(1)
-			}
-
-			res, err := l.Predict(
-				str,
-				llama.SetTemperature(ctx.Float64("temperature")),
-				llama.SetTopP(ctx.Float64("topp")),
-				llama.SetTopK(ctx.Int("topk")),
-				llama.SetTokens(ctx.Int("tokens")),
-				llama.SetThreads(ctx.Int("threads")),
-			)
-			if err != nil {
-				fmt.Printf("predicting failed: %s", err)
-				os.Exit(1)
-			}
-			fmt.Println(res)
-			return nil
+			return api.Start(model.NewModelLoader(ctx.String("models-path")), ctx.String("address"), ctx.Int("threads"), ctx.Int("context-size"), ctx.Bool("f16"))
 		},
 	}
 
-	err := app.Run(os.Args)
+	err = app.Run(os.Args)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
After some thoughts, it is clear that this project must be renamed - not only due to the fact that we don't support only llama, but also because of the API-focused direction that we are taking. 

There are already several CLI that can be used, and most importantly, every model ships typically a CLI with it, and if not, the llama.cpp CLI can just be used instead. 

It also ease out of the burden of maintain more code, so we can focus on optimizations, and compatibility.

This PR:

- Drops the CLI interface
- Rename images
- Makes the first command just start the API


