### PR TITLE
Improve chat endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -286,7 +287,7 @@ func openAIEndpoint(chat, debug bool, loader *model.ModelLoader, threads, ctx in
 					llama.SetThreads(threads),
 				}
 				if chat {
-					// TODO: why does <|SYSTEM|> stopword cause null output?
+					// TODO: why does adding the <|SYSTEM|> stopword cause null output?
 					//predictOptions = append(predictOptions, llama.SetStopWords("<|USER|>", "<|SYSTEM|>"))
 					predictOptions = append(predictOptions, llama.SetStopWords("<|USER|>"))
 				}
@@ -341,6 +342,9 @@ func openAIEndpoint(chat, debug bool, loader *model.ModelLoader, threads, ctx in
 			}
 
 			if chat {
+				// TODO: workaround to remove <|SYSTEM|> messages as the stopword doesn't work
+				re := regexp.MustCompile("(?m)^<\\|SYSTEM\\|>.*$")
+				prediction = re.ReplaceAllString(prediction, "")
 				prediction = strings.TrimSpace(strings.TrimPrefix(prediction, "<|ASSISTANT|>"))
 				result = append(result, Choice{Message: &Message{Role: "assistant", Content: prediction}})
 			} else {

--- a/api/api.go
+++ b/api/api.go
@@ -176,9 +176,9 @@ func openAIEndpoint(chat, debug bool, loader *model.ModelLoader, threads, ctx in
 		predInput := input.Prompt
 		if chat {
 			mess := []string{}
-			// TODO: encode roles
 			for _, i := range input.Messages {
-				mess = append(mess, i.Content)
+				content := fmt.Sprint("<|", strings.ToUpper(i.Role), "|> ", i.Content)
+				mess = append(mess, content)
 			}
 
 			predInput = strings.Join(mess, "\n")
@@ -285,6 +285,11 @@ func openAIEndpoint(chat, debug bool, loader *model.ModelLoader, threads, ctx in
 					llama.SetTokens(tokens),
 					llama.SetThreads(threads),
 				}
+				if chat {
+					// TODO: why does <|SYSTEM|> stopword cause null output?
+					//predictOptions = append(predictOptions, llama.SetStopWords("<|USER|>", "<|SYSTEM|>"))
+					predictOptions = append(predictOptions, llama.SetStopWords("<|USER|>"))
+				}
 
 				if debug {
 					predictOptions = append(predictOptions, llama.Debug)
@@ -336,6 +341,7 @@ func openAIEndpoint(chat, debug bool, loader *model.ModelLoader, threads, ctx in
 			}
 
 			if chat {
+				prediction = strings.TrimSpace(strings.TrimPrefix(prediction, "<|ASSISTANT|>"))
 				result = append(result, Choice{Message: &Message{Role: "assistant", Content: prediction}})
 			} else {
 				result = append(result, Choice{Text: prediction})

--- a/prompt-templates/llama.tmpl
+++ b/prompt-templates/llama.tmpl
@@ -1,0 +1,6 @@
+<|SYSTEM|> Transcript of a dialog, where the user interacts with an AI assistant. The assistant is helpful, kind, honest, good at writing, and never fails to answer the user's requests immediately and with precision.
+<|USER|> Hello.
+<|ASSISTANT|> Hello. How may I help you today?
+<|USER|> Please tell me the largest city in Europe.
+<|ASSISTANT|> Sure. The largest city in Europe is Moscow, the capital of Russia.
+{{.Input}}


### PR DESCRIPTION
Improving the chat endpoint to work with `<|SYSTEM|>`, `<|USER|>` and `<|ASSISTANT|>` flags, including a model completion template for llama.

Issues: Using `<|SYSTEM|>` as a stopword causes llama to output an empty message (no `content` field), possibly due to the code in the gpt-j wrapper. Hence, a workaround has been added to remove `<|SYSTEM|>` messages.