### PR TITLE
examples: correct typo in README

### DIFF
--- a/examples/chatbot-ui/README.md
+++ b/examples/chatbot-ui/README.md
@@ -19,7 +19,7 @@ cd LocalAI/examples/chatbot-ui
 wget https://gpt4all.io/models/ggml-gpt4all-j.bin -O models/ggml-gpt4all-j
 
 # start with docker-compose
-docker compose up -d --build
+docker-compose up -d --build
 ```
 
 Open http://localhost:3000 for the Web UI.


### PR DESCRIPTION
This PR corrects a typo in the example's README as discussed in https://github.com/go-skynet/LocalAI/issues/90