### PR TITLE
Add EXPOSE to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN make build
 
 FROM debian:$DEBIAN_VERSION
 COPY --from=builder /build/local-ai /usr/bin/local-ai
+EXPOSE 8080
 ENTRYPOINT [ "/usr/bin/local-ai" ]


### PR DESCRIPTION
This hints adds a port picker for Docker Decktop on macOS.