### PR TITLE
Stop parameter of OpenAIRequest changed to String Array

### DIFF
--- a/api/openai.go
+++ b/api/openai.go
@@ -62,7 +62,7 @@ type OpenAIRequest struct {
 	Instruction string `json:"instruction" yaml:"instruction"`
 	Input       string `json:"input" yaml:"input"`
 
-	Stop string `json:"stop" yaml:"stop"`
+	Stop []string `json:"stop" yaml:"stop"`
 
 	// Messages is read only by chat/completion API calls
 	Messages []Message `json:"messages" yaml:"messages"`
@@ -116,8 +116,8 @@ func updateConfig(config *Config, input *OpenAIRequest) {
 		config.Maxtokens = input.Maxtokens
 	}
 
-	if input.Stop != "" {
-		config.StopWords = append(config.StopWords, input.Stop)
+	if len(input.Stop) != 0 {
+		config.StopWords = append(config.StopWords, input.Stop...)
 	}
 
 	if input.RepeatPenalty != 0 {


### PR DESCRIPTION
OpenAI allows up to 4 stopwords to be sent in a request, not a single string. Langchain at minimum uses this, but we should support this for feature compatibility with other OpenAI users. This PR makes no attempt to enforce a limit of 4 stopwords - perhaps they have a good reason to, but we'll find out!

If you find this PR while investigating a breaking change, just send a single element array ["stopword"] instead of a single string in your request to LocalAI.