### PR TITLE
fix: missing returning error and free callback stream

### DIFF
--- a/api/prediction.go
+++ b/api/prediction.go
@@ -261,10 +261,15 @@ func ModelInference(s string, loader *model.ModelLoader, c Config, tokenCallback
 				predictOptions = append(predictOptions, llama.SetSeed(c.Seed))
 			}
 
-			return model.Predict(
+			str, er := model.Predict(
 				s,
 				predictOptions...,
 			)
+			// Seems that if we don't free the callback explicitly we leave functions registered (that might try to send on closed channels)
+			// For instance otherwise the API returns: {"error":{"code":500,"message":"send on closed channel","type":""}}
+			// after a stream event has occurred
+			model.SetTokenCallback(nil)
+			return str, er
 		}
 	}
 

--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -81,10 +81,9 @@ func (ml *ModelLoader) TemplatePrefix(modelName string, in interface{}) (string,
 		if exists {
 			m = t
 		}
-
 	}
 	if m == nil {
-		return "", nil
+		return "", fmt.Errorf("failed loading any template")
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
This fixes #180 and a nasty bug when after streams we use API calls not-streamed. seems the GC was not freeing functions so we were trying to send on a closed channel