### PR TITLE
docker: add openblas and opencv to images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ ARG GO_VERSION=1.20
 ARG BUILD_TYPE=
 FROM golang:$GO_VERSION
 WORKDIR /build
-RUN apt-get update && apt-get install -y cmake
+RUN apt-get update && apt-get install -y cmake libgomp1 libopenblas-dev libopenblas-base libopencv-dev libopencv-core-dev libopencv-core4.5 
 COPY . .
+RUN ln -s /usr/include/opencv4/opencv2/ /usr/include/opencv2
 RUN make prepare-sources
 EXPOSE 8080
 ENTRYPOINT [ "/build/entrypoint.sh" ]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,8 @@ ARG BUILD_TYPE=
 
 FROM golang:$GO_VERSION as builder
 WORKDIR /build
-RUN apt-get update && apt-get install -y cmake
+RUN apt-get update && apt-get install -y cmake libgomp1 libopenblas-dev libopenblas-base libopencv-dev libopencv-core-dev libopencv-core4.5 
+RUN ln -s /usr/include/opencv4/opencv2/ /usr/include/opencv2
 COPY . .
 RUN make build
 


### PR DESCRIPTION
This adds openblas and opencv to the images so can be started with `GO_TAGS=stablediffusion`