### PR TITLE
feat: minor enhancements to /models/apply

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -9,6 +9,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: ci-tests-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
 jobs:
   ubuntu-latest:
     runs-on: ubuntu-latest

--- a/api/gallery.go
+++ b/api/gallery.go
@@ -110,7 +110,7 @@ func (g *galleryApplier) start(c context.Context, cm *ConfigMerger) {
 type ApplyGalleryModelRequest struct {
 	URL             string         `json:"url"`
 	Name            string         `json:"name"`
-	AdditionalFiles []gallery.File `json:"file"`
+	AdditionalFiles []gallery.File `json:"files"`
 }
 
 func getOpStatus(g *galleryApplier) func(c *fiber.Ctx) error {

--- a/api/gallery.go
+++ b/api/gallery.go
@@ -86,6 +86,8 @@ func (g *galleryApplier) start(c context.Context, cm *ConfigMerger) {
 					continue
 				}
 
+				config.Files = append(config.Files, op.req.AdditionalFiles...)
+
 				if err := gallery.Apply(g.modelPath, op.req.Name, &config); err != nil {
 					updateError(err)
 					continue
@@ -106,8 +108,9 @@ func (g *galleryApplier) start(c context.Context, cm *ConfigMerger) {
 // endpoints
 
 type ApplyGalleryModelRequest struct {
-	URL  string `json:"url"`
-	Name string `json:"name"`
+	URL             string         `json:"url"`
+	Name            string         `json:"name"`
+	AdditionalFiles []gallery.File `json:"file"`
 }
 
 func getOpStatus(g *galleryApplier) func(c *fiber.Ctx) error {

--- a/pkg/gallery/models.go
+++ b/pkg/gallery/models.go
@@ -89,18 +89,7 @@ func inTrustedRoot(path string, trustedRoot string) error {
 
 func verifyPath(path, basePath string) error {
 	c := filepath.Clean(filepath.Join(basePath, path))
-
-	r, err := filepath.EvalSymlinks(c)
-	if err != nil {
-		return fmt.Errorf("unsafe or invalid path specified")
-	}
-
-	err = inTrustedRoot(r, basePath)
-	if err != nil {
-		return fmt.Errorf("unsafe or invalid path specified")
-	}
-
-	return nil
+	return inTrustedRoot(c, basePath)
 }
 
 func Apply(basePath, nameOverride string, config *Config) error {

--- a/pkg/gallery/models.go
+++ b/pkg/gallery/models.go
@@ -2,7 +2,6 @@ package gallery
 
 import (
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -85,7 +84,7 @@ func inTrustedRoot(path string, trustedRoot string) error {
 			return nil
 		}
 	}
-	return errors.New("path is outside of trusted root")
+	return fmt.Errorf("path is outside of trusted root")
 }
 
 func verifyPath(path, basePath string) error {
@@ -93,12 +92,12 @@ func verifyPath(path, basePath string) error {
 
 	r, err := filepath.EvalSymlinks(c)
 	if err != nil {
-		return errors.New("unsafe or invalid path specified")
+		return fmt.Errorf("unsafe or invalid path specified")
 	}
 
 	err = inTrustedRoot(r, basePath)
 	if err != nil {
-		return errors.New("unsafe or invalid path specified")
+		return fmt.Errorf("unsafe or invalid path specified")
 	}
 
 	return nil

--- a/pkg/gallery/models.go
+++ b/pkg/gallery/models.go
@@ -51,9 +51,9 @@ type Config struct {
 }
 
 type File struct {
-	Filename string `yaml:"filename"`
-	SHA256   string `yaml:"sha256"`
-	URI      string `yaml:"uri"`
+	Filename string `yaml:"filename" json:"filename"`
+	SHA256   string `yaml:"sha256" json:"sha256"`
+	URI      string `yaml:"uri" json:"uri"`
 }
 
 type PromptTemplate struct {

--- a/pkg/gallery/models_test.go
+++ b/pkg/gallery/models_test.go
@@ -26,5 +26,30 @@ var _ = Describe("Model test", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})
+		It("renames model correctly", func() {
+			tempdir, err := os.MkdirTemp("", "test")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tempdir)
+			c, err := ReadConfigFile(filepath.Join(os.Getenv("FIXTURES"), "gallery_simple.yaml"))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = Apply(tempdir, "foo", c)
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, f := range []string{"cerebras", "cerebras-completion.tmpl", "cerebras-chat.tmpl", "foo.yaml"} {
+				_, err = os.Stat(filepath.Join(tempdir, f))
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+		It("catches path traversals", func() {
+			tempdir, err := os.MkdirTemp("", "test")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tempdir)
+			c, err := ReadConfigFile(filepath.Join(os.Getenv("FIXTURES"), "gallery_simple.yaml"))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = Apply(tempdir, "../../../foo", c)
+			Expect(err).To(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
this change allow to specify from the API caller also additional files to download with the model definition as an array of `files`:

```
curl -s http://localhost:8080/models/apply -H "Content-Type: application/json" -d '{"name":"test", "url": "https://gist.githubusercontent.com/mudler/6112666e77061fe35ca3a535d25ccddc/raw/45eabb442f25db5bc991f2d2a616c15d4c26be67/gpt4all-j-localai.yaml", "files": [ { "uri": "<url>", "name": "filename" } ]}'
```

Besides, allow to override the name of the model - so can be used for instance to alias other models ( `gpt-3.5-turbo`, .. )

Also adds security checks such as any path we pass by in the model files cannot be traversed.


Related to #100 