### PR TITLE
fix: Dockerfile.build missing cmake in rwkv example

### DIFF
--- a/examples/rwkv/.gitignore
+++ b/examples/rwkv/.gitignore
@@ -1,0 +1,2 @@
+models/rwkv
+models/rwkv.tokenizer.json

--- a/examples/rwkv/Dockerfile.build
+++ b/examples/rwkv/Dockerfile.build
@@ -1,5 +1,7 @@
 FROM python
 
+RUN apt-get update && apt-get -y install cmake
+
 # convert the model (one-off)
 RUN pip3 install torch numpy
 


### PR DESCRIPTION
Fixes the following issue:
```
❯ docker build -t rwkv-converter -f Dockerfile.build .
...
 => ERROR [5/5] RUN git clone --recurse-submodules https://github.com/saharNooby/rwkv.cpp && cd rwkv.cpp && cmake . && cmake --build . --config Release                                                                              2.2s
------                                                                                                                                                                                                                                    
 > [5/5] RUN git clone --recurse-submodules https://github.com/saharNooby/rwkv.cpp && cd rwkv.cpp && cmake . && cmake --build . --config Release:                                                                                         
#0 0.191 Cloning into 'rwkv.cpp'...                                                                                                                                                                                                       
#0 1.272 Submodule 'ggml' (https://github.com/ggerganov/ggml) registered for path 'ggml'
#0 1.278 Cloning into '/build/rwkv.cpp/ggml'...
#0 2.168 Submodule path 'ggml': checked out 'ff6e03cbcd9bf6e9fa41d49f2495c042efae4dc6'
#0 2.177 /bin/sh: 1: cmake: not found
```