### PR TITLE
feat: allow to preload models before startup via env var or configs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -69,6 +69,18 @@ func App(opts ...AppOption) *fiber.App {
 	// Default middleware config
 	app.Use(recover.New())
 
+	if options.preloadJSONModels != "" {
+		if err := ApplyGalleryFromString(options.loader.ModelPath, options.preloadJSONModels, cm); err != nil {
+			return nil
+		}
+	}
+
+	if options.preloadModelsFromPath != "" {
+		if err := ApplyGalleryFromFile(options.loader.ModelPath, options.preloadModelsFromPath, cm); err != nil {
+			return nil
+		}
+	}
+
 	if options.cors {
 		if options.corsAllowOrigins == "" {
 			app.Use(cors.New())

--- a/api/options.go
+++ b/api/options.go
@@ -15,6 +15,8 @@ type Option struct {
 	debug, disableMessage           bool
 	imageDir                        string
 	cors                            bool
+	preloadJSONModels               string
+	preloadModelsFromPath           string
 	corsAllowOrigins                string
 }
 
@@ -53,6 +55,17 @@ func WithContext(ctx context.Context) AppOption {
 	}
 }
 
+func WithYAMLConfigPreload(configFile string) AppOption {
+	return func(o *Option) {
+		o.preloadModelsFromPath = configFile
+	}
+}
+
+func WithJSONStringPreload(configFile string) AppOption {
+	return func(o *Option) {
+		o.preloadJSONModels = configFile
+	}
+}
 func WithConfigFile(configFile string) AppOption {
 	return func(o *Option) {
 		o.configFile = configFile

--- a/main.go
+++ b/main.go
@@ -54,6 +54,16 @@ func main() {
 				Value:       filepath.Join(path, "models"),
 			},
 			&cli.StringFlag{
+				Name:        "preload-models",
+				DefaultText: "A List of models to apply in JSON at start",
+				EnvVars:     []string{"PRELOAD_MODELS"},
+			},
+			&cli.StringFlag{
+				Name:        "preload-models-config",
+				DefaultText: "A List of models to apply at startup. Path to a YAML config file",
+				EnvVars:     []string{"PRELOAD_MODELS_CONFIG"},
+			},
+			&cli.StringFlag{
 				Name:        "config-file",
 				DefaultText: "Config file",
 				EnvVars:     []string{"CONFIG_FILE"},
@@ -103,6 +113,8 @@ It uses llama.cpp, ggml and gpt4all as backend with golang c bindings.
 			fmt.Printf("Starting LocalAI using %d threads, with models path: %s\n", ctx.Int("threads"), ctx.String("models-path"))
 			return api.App(
 				api.WithConfigFile(ctx.String("config-file")),
+				api.WithJSONStringPreload(ctx.String("preload-models")),
+				api.WithYAMLConfigPreload(ctx.String("preload-models-config")),
 				api.WithModelLoader(model.NewModelLoader(ctx.String("models-path"))),
 				api.WithContextSize(ctx.Int("context-size")),
 				api.WithDebug(ctx.Bool("debug")),


### PR DESCRIPTION
**Description**

This allows to preload models on startup before the API is started by allowing to specify a list of models (as consumed by `models/apply` in a YAML file with `PRELOAD_MODELS_CONFIG` or a JSON string with `PRELOAD_MODELS`, useful for e.g. running in a container/pod).

I'll update docs afterwards. I'd like to consolidate examples using this method, so there are no extra action for the users to setup models.