### PR TITLE
ci: fix typo in variable name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Clone
         uses: actions/checkout@v3
-        with: 
+        with:
           submodules: true
       - name: Dependencies
         run: |
@@ -29,7 +29,7 @@ jobs:
       - name: Build
         id: build
         env:
-          CMAKE_ARGS: "${{ matrix.define }}"
+          CMAKE_ARGS: "${{ matrix.defines }}"
           BUILD_ID: "${{ matrix.build }}"
         run: |
           make dist
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Clone
         uses: actions/checkout@v3
-        with: 
+        with:
           submodules: true
 
       - name: Dependencies
@@ -68,7 +68,7 @@ jobs:
       - name: Build
         id: build
         env:
-          CMAKE_ARGS: "${{ matrix.define }}"
+          CMAKE_ARGS: "${{ matrix.defines }}"
           BUILD_ID: "${{ matrix.build }}"
         run: |
           make dist


### PR DESCRIPTION
**Description**

This PR fixes the build options in the CI. A small typo in the variable that set some options to build for AVX/AVX2/AVX512.

**Notes for Reviewers**

See result here: https://github.com/sebastien-prudhomme/LocalAI/actions/runs/5114923609

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 