### PR TITLE
fix: do not build from the same container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG GO_VERSION=1.20
-FROM golang:$GO_VERSION
+
+FROM golang:$GO_VERSION as builder
 
 ARG BUILD_TYPE=
 ARG GO_TAGS=
@@ -40,6 +41,53 @@ RUN apt-get install -y libopencv-dev && \
 
 COPY . .
 RUN make build
+
+FROM golang:$GO_VERSION
+
+ARG BUILD_TYPE=
+ARG GO_TAGS=
+ARG CUDA_MAJOR_VERSION=11
+ARG CUDA_MINOR_VERSION=7
+
+ENV BUILD_TYPE=${BUILD_TYPE}
+ENV GO_TAGS=${GO_TAGS}
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+ENV NVIDIA_REQUIRE_CUDA="cuda>=${CUDA_MAJOR_VERSION}.0"
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV HEALTHCHECK_ENDPOINT=http://localhost:8080/readyz
+ENV HEALTHCHECK_TIMEOUT=10m
+ENV HEALTHCHECK_INTERVAL=10m
+ENV HEALTHCHECK_RETRIES=10m
+
+ENV REBUILD=true
+
+WORKDIR /build
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates cmake curl
+
+# CuBLAS requirements
+RUN if [ "${BUILD_TYPE}" = "cublas" ]; then \
+    apt-get install -y software-properties-common && \
+    apt-add-repository contrib && \
+    curl -O https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64/cuda-keyring_1.0-1_all.deb && \
+    dpkg -i cuda-keyring_1.0-1_all.deb && \
+    rm -f cuda-keyring_1.0-1_all.deb && \
+    apt-get update && \
+    apt-get install -y cuda-nvcc-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} libcublas-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
+    ; fi
+ENV PATH /usr/local/cuda/bin:${PATH}
+
+# OpenBLAS requirements
+RUN apt-get install -y libopenblas-dev
+
+# Stable Diffusion requirements
+RUN apt-get install -y libopencv-dev && \
+    ln -s /usr/include/opencv4/opencv2 /usr/include/opencv2
+
+COPY . .
+RUN make prepare-sources
+COPY --from=builder /build/local-ai ./
 
 # Define the health check command
 HEALTHCHECK --interval=1m --timeout=10m --retries=10 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
+set -e
 
 cd /build
 
 if [ "$REBUILD" != "false" ]; then
-	make rebuild
+	rm -rf ./local-ai
+	make build
 fi
 
 ./local-ai "$@"


### PR DESCRIPTION
We are not cleaning up properly, and this causes leftovers to stay around when rebuilding the first time. This ends up to link objects during startup of the container with objects compiled with a different CPU flagset, and giving out SIGILL like:

```
chatbot-ui-api-1      | SIGILL: illegal instruction
chatbot-ui-api-1      | PC=0xa17ced m=7 sigcode=2
chatbot-ui-api-1      | signal arrived during cgo execution
chatbot-ui-api-1      | instruction bytes: 0x62 0xf2 0xf5 0x8 0x3f 0xc0
0xc4 0xe1 0xf9 0x7e 0xc2 0x48 0x1 0xd0 0xf 0x92
chatbot-ui-api-1      |
chatbot-ui-api-1      | goroutine 31 [syscall]:
chatbot-ui-api-1      | runtime.cgocall(0x97f700, 0xc0002d6460)
chatbot-ui-api-1      |         /usr/local/go/src/runtime/cgocall.go:157
+0x5c fp=0xc0002d6438 sp=0xc0002d6400 pc=0x44cd3c
```

**Description**

This PR might possibly alleviate #288 https://github.com/go-skynet/LocalAI/issues/86

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to LocalAI! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->