### PR TITLE
feat: display download progress when installing models

### DIFF
--- a/pkg/gallery/models_test.go
+++ b/pkg/gallery/models_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Model test", func() {
 			c, err := ReadConfigFile(filepath.Join(os.Getenv("FIXTURES"), "gallery_simple.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 
-			err = Apply(tempdir, "", c, map[string]interface{}{})
+			err = Apply(tempdir, "", c, map[string]interface{}{}, func(string, string, string, float64) {})
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, f := range []string{"cerebras", "cerebras-completion.tmpl", "cerebras-chat.tmpl", "cerebras.yaml"} {
@@ -45,7 +45,7 @@ var _ = Describe("Model test", func() {
 			c, err := ReadConfigFile(filepath.Join(os.Getenv("FIXTURES"), "gallery_simple.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 
-			err = Apply(tempdir, "foo", c, map[string]interface{}{})
+			err = Apply(tempdir, "foo", c, map[string]interface{}{}, func(string, string, string, float64) {})
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, f := range []string{"cerebras", "cerebras-completion.tmpl", "cerebras-chat.tmpl", "foo.yaml"} {
@@ -61,7 +61,7 @@ var _ = Describe("Model test", func() {
 			c, err := ReadConfigFile(filepath.Join(os.Getenv("FIXTURES"), "gallery_simple.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 
-			err = Apply(tempdir, "foo", c, map[string]interface{}{"backend": "foo"})
+			err = Apply(tempdir, "foo", c, map[string]interface{}{"backend": "foo"}, func(string, string, string, float64) {})
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, f := range []string{"cerebras", "cerebras-completion.tmpl", "cerebras-chat.tmpl", "foo.yaml"} {
@@ -87,7 +87,7 @@ var _ = Describe("Model test", func() {
 			c, err := ReadConfigFile(filepath.Join(os.Getenv("FIXTURES"), "gallery_simple.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 
-			err = Apply(tempdir, "../../../foo", c, map[string]interface{}{})
+			err = Apply(tempdir, "../../../foo", c, map[string]interface{}{}, func(string, string, string, float64) {})
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
**Description**

This PR allows to track progress of the download with the API and from the terminal (when debug is enabled):

```bash
$ LOCALAI=http://localhost:8080                                         
$ curl $LOCALAI/models/apply -H "Content-Type: application/json" -d '{
     "url": "github:go-skynet/model-gallery/rwkv-raven-1b.yaml",
     "name": "rwkv"
   }'

# ... from logs
7:00PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 48.4 MiB/1.1 GiB (4.41%) ETA: 1m48.55284203s
7:00PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 109.3 MiB/1.1 GiB (9.96%) ETA: 1m30.525148835s
7:00PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 158.7 MiB/1.1 GiB (14.46%) ETA: 1m28.87224456s
7:00PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 215.1 MiB/1.1 GiB (19.61%) ETA: 1m22.113138948s
7:01PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 269.1 MiB/1.1 GiB (24.54%) ETA: 1m16.994476305s
7:01PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 332.3 MiB/1.1 GiB (30.29%) ETA: 1m9.112335728s
7:01PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 396.6 MiB/1.1 GiB (36.16%) ETA: 1m1.87463023s
7:01PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 464.1 MiB/1.1 GiB (42.31%) ETA: 54.601703227s
7:01PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 529.2 MiB/1.1 GiB (48.25%) ETA: 48.323000654s
7:01PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 597.3 MiB/1.1 GiB (54.46%) ETA: 41.858577168s
7:01PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 664.1 MiB/1.1 GiB (60.55%) ETA: 35.874844919s
7:01PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 730.6 MiB/1.1 GiB (66.61%) ETA: 30.103736682s
7:01PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 796.7 MiB/1.1 GiB (72.63%) ETA: 24.519454404s
7:01PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 866.3 MiB/1.1 GiB (78.97%) ETA: 18.656292592s
7:01PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 933.6 MiB/1.1 GiB (85.11%) ETA: 13.13222735s
7:01PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 1003.4 MiB/1.1 GiB (91.48%) ETA: 7.457932404s
7:02PM DBG Downloading RWKV-4-Raven-1B5-v11-Eng99%2525-Other1%2525-20230425-ctx4096_Q4_0.bin: 1.0 GiB/1.1 GiB (97.74%) ETA: 1.965665484s
```

From the API:

```bash
$ curl http://localhost:8080/models/jobs/2a4cf365-061c-11ee-8cb5-c4cbe106d571                        
# {"error":null,"processed":false,"message":"processing","progress":11.597648752235902,"file_size":"1.1 GiB","downloaded_size":"127.2 MiB"}
```