### PR TITLE
fix: copy metal file from build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ release/
 
 # Generated during build
 backend-assets/
+
+/ggml-metal.metal

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,9 @@ build: prepare ## Build the project
 	$(info ${GREEN}I BUILD_TYPE: ${YELLOW}$(BUILD_TYPE)${RESET})
 	$(info ${GREEN}I GO_TAGS: ${YELLOW}$(GO_TAGS)${RESET})
 	CGO_LDFLAGS="$(CGO_LDFLAGS)" C_INCLUDE_PATH=${C_INCLUDE_PATH} LIBRARY_PATH=${LIBRARY_PATH} $(GOCMD) build -ldflags "$(LD_FLAGS)" -tags "$(GO_TAGS)" -o $(BINARY_NAME) ./
+ifeq ($(BUILD_TYPE),metal)
+	cp go-llama/build/bin/ggml-metal.metal .
+endif
 
 dist: build
 	mkdir -p release


### PR DESCRIPTION
This ties the metal file to the build and reduces the steps the user has to take to run local-ai
