### PR TITLE
fix: set default batch size

### DIFF
--- a/api/prediction.go
+++ b/api/prediction.go
@@ -44,6 +44,8 @@ func defaultLLamaOpts(c Config) []llama.ModelOption {
 	llamaOpts = append(llamaOpts, llama.SetTensorSplit(c.TensorSplit))
 	if c.Batch != 0 {
 		llamaOpts = append(llamaOpts, llama.SetNBatch(c.Batch))
+	} else {
+		llamaOpts = append(llamaOpts, llama.SetNBatch(512))
 	}
 
 	return llamaOpts


### PR DESCRIPTION
**Description**

This PR fixes cublas acceleration. A default of 0 would not allow to allocate ram for scratch buffers. Setting that to the same defaults of llama.cpp

Fixes #556

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to LocalAI! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->