### PR TITLE
feat: split building process by several scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,35 @@
 ARG GO_VERSION=1.20-bullseye
-
 FROM golang:$GO_VERSION as requirements
 
+# [Option] Upgrade OS packages to their latest versions
+ARG UPGRADE_PACKAGES="$true"
+
+COPY scripts/debian.sh /tmp/library-scripts/
+RUN bash /tmp/library-scripts/debian.sh "${UPGRADE_PACKAGES}" \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+# Install CuBLAS
 ARG BUILD_TYPE
-ARG CUDA_MAJOR_VERSION=11
-ARG CUDA_MINOR_VERSION=7
+ARG KEYRING_VERSION="1.0-1"
+ARG CUDA_MAJOR_VERSION="11"
+ARG CUDA_MINOR_VERSION="7"
 
-ENV BUILD_TYPE=${BUILD_TYPE}
-
-RUN apt-get update && \
-    apt-get install -y ca-certificates cmake curl patch
-
-# CuBLAS requirements
-RUN if [ "${BUILD_TYPE}" = "cublas" ]; then \
-    apt-get install -y software-properties-common && \
-    apt-add-repository contrib && \
-    curl -O https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64/cuda-keyring_1.0-1_all.deb && \
-    dpkg -i cuda-keyring_1.0-1_all.deb && \
-    rm -f cuda-keyring_1.0-1_all.deb && \
-    apt-get update && \
-    apt-get install -y cuda-nvcc-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} libcublas-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
-    ; fi
+# ENV BUILD_TYPE=${BUILD_TYPE}
+COPY scripts/cu-blas.sh /tmp/library-scripts/
+RUN bash /tmp/library-scripts/cu-blas.sh "${BUILD_TYPE}" "${KEYRING_VERSION}" "${CUDA_MAJOR_VERSION} ${CUDA_MINOR_VERSION}" \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 ENV PATH /usr/local/cuda/bin:${PATH}
 
-# OpenBLAS requirements
-RUN apt-get install -y libopenblas-dev
+# Install OpenBLAS 
+COPY scripts/open-blas.sh /tmp/library-scripts/
+RUN bash /tmp/library-scripts/open-blas.sh \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 
-# Stable Diffusion requirements
-RUN apt-get install -y libopencv-dev && \
-    ln -s /usr/include/opencv4/opencv2 /usr/include/opencv2
+# Install Stable Diffusion requirements
+COPY scripts/stable-diffusion.sh /tmp/library-scripts/
+RUN bash /tmp/library-scripts/stable-diffusion.sh \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
 
 FROM requirements as builder
 
@@ -44,6 +45,7 @@ WORKDIR /build
 COPY . .
 RUN make build
 
+
 FROM requirements
 
 ARG FFMPEG
@@ -51,10 +53,10 @@ ARG FFMPEG
 ENV REBUILD=true
 ENV HEALTHCHECK_ENDPOINT=http://localhost:8080/readyz
 
-# Add FFmpeg
-RUN if [ "${FFMPEG}" = "true" ]; then \
-    apt-get install -y ffmpeg \
-    ; fi
+# Install FFmpeg
+COPY scripts/ffmpeg.sh /tmp/library-scripts/
+RUN bash /tmp/library-scripts/ffmpeg.sh "${FFMPEG}" \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 
 WORKDIR /build
 

--- a/scripts/cu-blas.sh
+++ b/scripts/cu-blas.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Syntax: ./cu-blas.sh [KEYRING_VERSION] [CUDA_MAJOR_VERSION] [CUDA_MINOR_VERSION]
+
+set -e
+
+BUILD_TYPE=${1:-"none"}
+KEYRING_VERSION=${2:-"1.0-1"}
+CUDA_MAJOR_VERSION=${3:-"11"}
+CUDA_MINOR_VERSION=${4:-"7"}
+
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install software-properties-common
+if [ "${BUILD_TYPE}" = "cublas" ] && ! dpkg -s software-properties-common > /dev/null 2>&1; then
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        apt-get update
+    fi
+    apt-get -y install --no-install-recommends software-properties-common
+fi
+
+# Install cuda-keyring
+CUDA_KEYRING_SCRIPT="$(cat <<EOF
+    set -e
+    # Wrapper function to only use sudo if not already root
+    sudoIf()
+    {
+        if [ "\$(id -u)" -ne 0 ]; then
+            sudo "\$@"
+        else
+            "\$@"
+        fi
+    }
+    sudoIf apt-add-repository contrib
+    echo "Downloading Cuda-Keyring ${KEYRING_VERSION}..."
+    curl -sSL -o /tmp/cuda-keyring_${KEYRING_VERSION}_all.deb "https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64/cuda-keyring_${KEYRING_VERSION}_all.deb"
+    dpkg -i cuda-keyring_${KEYRING_VERSION}_all.deb
+    sudoIf apt-get update
+    sudoIf apt-get -y install --no-install-recommends cuda-nvcc-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} libcublas-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION}
+EOF
+)"
+
+if [ "${BUILD_TYPE}" = "cublas" ] > /dev/null 2>&1; then
+    "${SCHEME_INSTALL_SCRIPT}"
+else
+    echo "Cuda keyring already installed. Skipping."
+fi
+
+echo "Done!"

--- a/scripts/debian.sh
+++ b/scripts/debian.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Syntax: ./debian.sh [upgrade packages flag]
+
+set -e
+
+UPGRADE_PACKAGES=${1:-"true"}
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Function to call apt-get if needed
+apt_get_update_if_needed()
+{
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update
+    else
+        echo "Skipping apt-get update."
+    fi
+}
+
+# Get to latest versions of all packages
+if [ "${UPGRADE_PACKAGES}" = "true" ]; then
+    apt_get_update_if_needed
+    apt-get -y upgrade --no-install-recommends
+    apt-get autoremove -y
+fi
+
+# Run install apt-utils to avoid debconf warning then verify presence of other common developer tools and dependencies
+if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
+    apt_get_update_if_needed
+
+    package_list="apt-utils \
+        ca-certificates \
+        cmake \
+        patch \
+        curl"
+
+    echo "Packages to verify are installed: ${package_list}"
+    apt-get -y install --no-install-recommends ${package_list} 2> >( grep -v 'debconf: delaying package configuration, since apt-utils is not installed' >&2 )
+
+    PACKAGES_ALREADY_INSTALLED="true"
+fi
+
+echo "Done!"

--- a/scripts/ffmpeg.sh
+++ b/scripts/ffmpeg.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Syntax: ./ffmpeg.sh [upgrade packages flag]
+
+set -e
+
+FFMPEG=${1:-"false"}
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Install ffmpeg
+if [ "${FFMPEG}" = "true" ] && ! dpkg -s ffmpeg > /dev/null 2>&1; then
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        apt-get update
+    fi
+    apt-get -y install --no-install-recommends ffmpeg
+fi
+
+echo "Done!"

--- a/scripts/open-blas.sh
+++ b/scripts/open-blas.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Syntax: ./open-blash.sh
+
+set -e
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Install software-properties-common
+if ! dpkg -s libopenblas-dev > /dev/null 2>&1; then
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        apt-get update
+    fi
+    apt-get -y install --no-install-recommends libopenblas-dev
+fi
+
+echo "Done!"

--- a/scripts/stable-diffusion.sh
+++ b/scripts/stable-diffusion.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Syntax: ./stable-diffusion.sh
+
+set -e
+
+if ! dpkg -s libopencv-dev > /dev/null 2>&1; then
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        apt-get update
+    fi
+    apt-get -y install --no-install-recommends libopencv-dev
+    ln -s /usr/include/opencv4/opencv2 /usr/include/opencv2
+fi
+
+echo "Done!"


### PR DESCRIPTION
**Description**
We face so many models and build them locally together, but it is hard to check if something goes wrong. If we can split the building steps into several bash scripts and allow input of some variants to control the logic of the building process, it should make our life easier. 

~This PR does not fix the build error, it still occurs in the container environment.~ The building error has been fixed by the commit https://github.com/go-skynet/LocalAI/commit/d3d3187e512d7ce93d1184207d6b3a5f2bae762e 

cc @mudler Are you interested in this proposal?

**More ideas**
* Shall we add `ARG` to support do not install specific models like the `Stable Diffusion` (I mean we can add docker build command to the Makefile)?  https://github.com/go-skynet/LocalAI/issues/614
* Shall we add docker build into Makefile? If yes, I will do this PR.
* Shall we enable `make build` and `make prepare-resources` to run in parallel consequence(in a container environment) to decrease the building time?


The building time of this PR is inside 4 Core 8 GB memory containers.
```
@Aisuko ➜ /workspaces/LocalAI (dockerfile) $ docker build --no-cache -t localai .                                                                                                                                                                       
[+] Building 890.5s (23/23) FINISHED                                                                                                                                                                                                                    
 => [internal] load build definition from Dockerfile                                                                                                                                                                                               0.2s 
 => => transferring dockerfile: 2.07kB                                                                                                                                                                                                             0.0s 
 => [internal] load .dockerignore                                                                                                                                                                                                                  0.3s 
 => => transferring context: 34B                                                                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/golang:1.20-bullseye                                                                                                                                                                            1.0s
 => [internal] load build context                                                                                                                                                                                                                  0.2s
 => => transferring context: 12.56kB                                                                                                                                                                                                               0.0s
 => CACHED [requirements 1/9] FROM docker.io/library/golang:1.20-bullseye@sha256:a3598b93d32819f1759893c532fa186bc61d58f1ced9aa49c2c77fe13383159a                                                                                                  0.0s
 => [requirements 2/9] COPY scripts/debian.sh /tmp/library-scripts/                                                                                                                                                                                0.4s
 => [requirements 3/9] RUN bash /tmp/library-scripts/debian.sh ""     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts                                                                                                     12.8s
 => [requirements 4/9] COPY scripts/cu-blas.sh /tmp/library-scripts/                                                                                                                                                                               0.4s 
 => [requirements 5/9] RUN bash /tmp/library-scripts/cu-blas.sh "${BUILD_TYPE}" "1.0-1" "11 7"     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts                                                                         0.8s 
 => [requirements 6/9] COPY scripts/open-blas.sh /tmp/library-scripts/                                                                                                                                                                             0.4s 
 => [requirements 7/9] RUN bash /tmp/library-scripts/open-blas.sh     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts                                                                                                      8.7s 
 => [requirements 8/9] COPY scripts/stable-diffusion.sh /tmp/library-scripts/                                                                                                                                                                      0.5s 
 => [requirements 9/9] RUN bash /tmp/library-scripts/stable-diffusion.sh     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts                                                                                             209.5s 
 => [stage-2 1/6] COPY scripts/ffmpeg.sh /tmp/library-scripts/                                                                                                                                                                                     0.9s 
 => [builder 1/3] WORKDIR /build                                                                                                                                                                                                                   0.7s 
 => [builder 2/3] COPY . .                                                                                                                                                                                                                         1.0s 
 => [stage-2 2/6] RUN bash /tmp/library-scripts/ffmpeg.sh "${FFMPEG}"     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts                                                                                                  1.4s 
 => [builder 3/3] RUN make build                                                                                                                                                                                                                 601.2s 
 => [stage-2 3/6] WORKDIR /build                                                                                                                                                                                                                   0.6s 
 => [stage-2 4/6] COPY . .                                                                                                                                                                                                                         0.5s
 => [stage-2 5/6] RUN make prepare-sources                                                                                                                                                                                                        81.7s
 => [stage-2 6/6] COPY --from=builder /build/local-ai ./                                                                                                                                                                                           0.8s 
 => exporting to image                                                                                                                                                                                                                            50.4s 
 => => exporting layers                                                                                                                                                                                                                           50.3s 
 => => writing image sha256:d418b8ccd0ba6d2cd7862e0d58dca9bb207b28f68ea2fdf2ebf3d8f6bb8161e9                                                                                                                                                       0.0s 
 => => naming to docker.io/library/localai 
```

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to LocalAI! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->