### PR TITLE
Docker preserve sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,9 @@ RUN curl -L "https://github.com/gabime/spdlog/archive/refs/tags/v${SPDLOG_VERSIO
 # \
 #    ; fi
 
+###################################
+###################################
+
 FROM requirements as builder
 
 ARG GO_TAGS="stablediffusion tts"
@@ -75,7 +78,10 @@ RUN make prepare
 COPY . .
 RUN ESPEAK_DATA=/build/lib/Linux-$(uname -m)/piper_phonemize/lib/espeak-ng-data make build
 
-FROM requirements
+###################################
+###################################
+
+FROM builder
 
 ARG FFMPEG
 
@@ -86,11 +92,6 @@ ENV HEALTHCHECK_ENDPOINT=http://localhost:8080/readyz
 RUN if [ "${FFMPEG}" = "true" ]; then \
     apt-get install -y ffmpeg \
     ; fi
-
-WORKDIR /build
-
-COPY --from=builder /build/local-ai ./
-COPY entrypoint.sh .
 
 # Define the health check command
 HEALTHCHECK --interval=1m --timeout=10m --retries=10 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -L "https://github.com/gabime/spdlog/archive/refs/tags/v${SPDLOG_VERSIO
     tar -C "lib/Linux-$(uname -m)/piper_phonemize" -xzvf - && ls -liah /build/lib/Linux-$(uname -m)/piper_phonemize/ && \
     cp -rfv /build/lib/Linux-$(uname -m)/piper_phonemize/lib/. /lib64/ && \
     cp -rfv /build/lib/Linux-$(uname -m)/piper_phonemize/lib/. /usr/lib/ && \
-    cp -rfv /build/lib/Linux-$(uname -m)/piper_phonemize/include/. /usr/include/ 
+    cp -rfv /build/lib/Linux-$(uname -m)/piper_phonemize/include/. /usr/include/
 # \
 #    ; fi
 
@@ -66,6 +66,12 @@ ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 ENV NVIDIA_REQUIRE_CUDA="cuda>=${CUDA_MAJOR_VERSION}.0"
 ENV NVIDIA_VISIBLE_DEVICES=all
 
+WORKDIR /build
+
+COPY Makefile .
+RUN make get-sources
+COPY go.mod .
+RUN make prepare
 COPY . .
 RUN ESPEAK_DATA=/build/lib/Linux-$(uname -m)/piper_phonemize/lib/espeak-ng-data make build
 
@@ -83,9 +89,8 @@ RUN if [ "${FFMPEG}" = "true" ]; then \
 
 WORKDIR /build
 
-COPY . .
-RUN make prepare-sources
 COPY --from=builder /build/local-ai ./
+COPY entrypoint.sh .
 
 # Define the health check command
 HEALTHCHECK --interval=1m --timeout=10m --retries=10 \

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ gpt4all/gpt4all-bindings/golang/libgpt4all.a: gpt4all
 	$(MAKE) -C gpt4all/gpt4all-bindings/golang/ libgpt4all.a
 
 ## CEREBRAS GPT
-go-ggml-transformers: 
+go-ggml-transformers:
 	git clone --recurse-submodules https://github.com/go-skynet/go-ggml-transformers.cpp go-ggml-transformers
 	cd go-ggml-transformers && git checkout -b build $(GOGPT2_VERSION) && git submodule update --init --recursive --depth 1
 	# This is hackish, but needed as both go-llama and go-gpt4allj have their own version of ggml..
@@ -194,7 +194,7 @@ go-llama:
 	git clone --recurse-submodules https://github.com/go-skynet/go-llama.cpp go-llama
 	cd go-llama && git checkout -b build $(GOLLAMA_VERSION) && git submodule update --init --recursive --depth 1
 
-go-llama/libbinding.a: go-llama 
+go-llama/libbinding.a: go-llama
 	$(MAKE) -C go-llama BUILD_TYPE=$(BUILD_TYPE) libbinding.a
 
 go-piper/libpiper_binding.a:

--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,9 @@ go-llama/libbinding.a: go-llama
 go-piper/libpiper_binding.a:
 	$(MAKE) -C go-piper libpiper_binding.a example/main
 
+get-sources: go-llama go-ggml-transformers gpt4all go-piper go-rwkv whisper.cpp go-bert bloomz go-stable-diffusion
+	touch $@
+
 replace:
 	$(GOCMD) mod edit -replace github.com/go-skynet/go-llama.cpp=$(shell pwd)/go-llama
 	$(GOCMD) mod edit -replace github.com/nomic-ai/gpt4all/gpt4all-bindings/golang=$(shell pwd)/gpt4all/gpt4all-bindings/golang
@@ -211,7 +214,7 @@ replace:
 	$(GOCMD) mod edit -replace github.com/mudler/go-stable-diffusion=$(shell pwd)/go-stable-diffusion
 	$(GOCMD) mod edit -replace github.com/mudler/go-piper=$(shell pwd)/go-piper
 
-prepare-sources: go-llama go-ggml-transformers gpt4all go-piper go-rwkv whisper.cpp go-bert bloomz go-stable-diffusion replace
+prepare-sources: get-sources replace
 	$(GOCMD) mod download
 
 ## GENERIC
@@ -228,6 +231,7 @@ rebuild: ## Rebuilds the project
 	$(MAKE) build
 
 prepare: prepare-sources backend-assets/gpt4all $(OPTIONAL_TARGETS) go-llama/libbinding.a go-bert/libgobert.a go-ggml-transformers/libtransformers.a go-rwkv/librwkv.a whisper.cpp/libwhisper.a bloomz/libbloomz.a  ## Prepares for building
+	touch $@
 
 clean: ## Remove build related file
 	rm -fr ./go-llama


### PR DESCRIPTION
**Description**

Redoes #590 in a way so as to not cause #615 (see explanation [here](https://github.com/go-skynet/LocalAI/pull/620#issuecomment-1602731560) in #620 )

**Testing**

tested both with and without `REBUILD` env var set

```
% docker run -it --rm -v ./models:/build/models --publish 8080:8080 local-ai-dev
go mod edit -replace github.com/go-skynet/go-llama.cpp=/build/go-llama
go mod edit -replace github.com/nomic-ai/gpt4all/gpt4all-bindings/golang=/build/gpt4all/gpt4all-bindings/golang
go mod edit -replace github.com/go-skynet/go-ggml-transformers.cpp=/build/go-ggml-transformers
go mod edit -replace github.com/donomii/go-rwkv.cpp=/build/go-rwkv
go mod edit -replace github.com/ggerganov/whisper.cpp=/build/whisper.cpp
go mod edit -replace github.com/go-skynet/go-bert.cpp=/build/go-bert
go mod edit -replace github.com/go-skynet/bloomz.cpp=/build/bloomz
go mod edit -replace github.com/mudler/go-stable-diffusion=/build/go-stable-diffusion
go mod download
touch prepare
I local-ai build info:
I BUILD_TYPE:
I GO_TAGS: stablediffusion
CGO_LDFLAGS="" C_INCLUDE_PATH=/build/go-llama:/build/go-stable-diffusion/:/build/gpt4all/gpt4all-bindings/golang/:/build/go-ggml-transformers:/build/go-rwkv:/build/whisper.cpp:/build/go-bert:/build/bloomz LIBRARY_PATH=/build/go-llama:/build/go-stable-diffusion/:/build/gpt4all/gpt4all-bindings/golang/:/build/go-ggml-transformers:/build/go-rwkv:/build/whisper.cpp:/build/go-bert:/build/bloomz go build -ldflags "?=" -tags "stablediffusion" -o local-ai ./
Starting LocalAI using 4 threads, with models path: /build/models

 ┌───────────────────────────────────────────────────┐
 │                   Fiber v2.47.0                   │
 │               http://127.0.0.1:8080               │
 │       (bound on host 0.0.0.0 and port 8080)       │
 │                                                   │
 │ Handlers ............ 23  Processes ........... 1 │
 │ Prefork ....... Disabled  PID ............... 227 │
 └───────────────────────────────────────────────────┘

^C%

% docker run -it --rm -v ./models:/build/models --publish 8080:8080 --env REBUILD=false local-ai-dev
Starting LocalAI using 4 threads, with models path: /build/models

 ┌───────────────────────────────────────────────────┐
 │                   Fiber v2.47.0                   │
 │               http://127.0.0.1:8080               │
 │       (bound on host 0.0.0.0 and port 8080)       │
 │                                                   │
 │ Handlers ............ 23  Processes ........... 1 │
 │ Prefork ....... Disabled  PID ................. 6 │
 └───────────────────────────────────────────────────┘

^C%
```


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to LocalAI! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->