### PR TITLE
Update entrypoint.sh to use $THREADS for parallel compilation on start if present

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ cd /build
 
 if [ "$REBUILD" != "false" ]; then
 	rm -rf ./local-ai
-	ESPEAK_DATA=/build/lib/Linux-$(uname -m)/piper_phonemize/lib/espeak-ng-data make build
+	ESPEAK_DATA=/build/lib/Linux-$(uname -m)/piper_phonemize/lib/espeak-ng-data make build -j${THREADS:-1}
 fi
 
 ./local-ai "$@"


### PR DESCRIPTION
**Description**
This updates entrypoint.sh to make use of the THREADS environment variable if present to speed up compilation on startup. In my case, I have an older, slower CPU which has 24 cores, so it makes a big difference for me. If that is not set, it will use 1 thread as it does now.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to LocalAI! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->