### PR TITLE
fix: split build threads from running threads

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ cd /build
 
 if [ "$REBUILD" != "false" ]; then
 	rm -rf ./local-ai
-	ESPEAK_DATA=/build/lib/Linux-$(uname -m)/piper_phonemize/lib/espeak-ng-data make build -j${THREADS:-1}
+	ESPEAK_DATA=/build/lib/Linux-$(uname -m)/piper_phonemize/lib/espeak-ng-data make build -j${BUILD_PARALLELISM:-1}
 fi
 
 ./local-ai "$@"


### PR DESCRIPTION
This can be particularly problematic when running on kubernetes where CPU limits can kill the pod.

@maccam912 this splits the env variable so it is not tied to the `THREADS` which is in runtime. In my k8s deployment LocalAI fails otherwise as overbooks my CPU and gets killed during start, and I'm pretty sure I won't be alone here.