### PR TITLE
[whisper] Partial support for verbose_json format in transcribe endpoint

### DIFF
--- a/api/openai.go
+++ b/api/openai.go
@@ -737,7 +737,7 @@ func transcriptEndpoint(cm *ConfigMerger, o *Option) func(c *fiber.Ctx) error {
 
 		log.Debug().Msgf("Trascribed: %+v", tr)
 		// TODO: handle different outputs here
-		return c.Status(http.StatusOK).JSON(fiber.Map{"text": tr})
+		return c.Status(http.StatusOK).JSON(tr)
 	}
 }
 


### PR DESCRIPTION
Extend the current output to be compatible with the `custom_json` format referenced in the [OpenAI docs](https://platform.openai.com/docs/api-reference/audio/create#audio/create-response_format)

This PR basically adds an extra field in response: 'segments', which contains text divided by time segments.

These changes can be useful for other tools that expect segmented text like some automatic subtitles or other tools like [Buzz](https://github.com/chidiwilliams/buzz)

Although support is not complete, those changes are enough to get Buzz working at least. More work is needed to perfectly support `custom_json` format.