### PR TITLE
Add API_KEY support

### DIFF
--- a/api/options.go
+++ b/api/options.go
@@ -23,6 +23,7 @@ type Option struct {
 	preloadJSONModels               string
 	preloadModelsFromPath           string
 	corsAllowOrigins                string
+	apiKey                          string
 
 	galleries []gallery.Gallery
 
@@ -165,5 +166,11 @@ func WithAudioDir(audioDir string) AppOption {
 func WithImageDir(imageDir string) AppOption {
 	return func(o *Option) {
 		o.imageDir = imageDir
+	}
+}
+
+func WithApiKey(apiKey string) AppOption {
+	return func(o *Option) {
+		o.apiKey = apiKey
 	}
 }

--- a/main.go
+++ b/main.go
@@ -110,6 +110,11 @@ func main() {
 				EnvVars: []string{"UPLOAD_LIMIT"},
 				Value:   15,
 			},
+			&cli.StringFlag{
+				Name:    "api-key",
+				Usage:   "API Key to enable API authentication. When this is set, all the requests must be authenticated with this API key.",
+				EnvVars: []string{"API_KEY"},
+			},
 		},
 		Description: `
 LocalAI is a drop-in replacement OpenAI API which runs inference locally.
@@ -145,7 +150,9 @@ For a list of compatible model, check out: https://localai.io/model-compatibilit
 				api.WithThreads(ctx.Int("threads")),
 				api.WithBackendAssets(backendAssets),
 				api.WithBackendAssetsOutput(ctx.String("backend-assets-path")),
-				api.WithUploadLimitMB(ctx.Int("upload-limit")))
+				api.WithUploadLimitMB(ctx.Int("upload-limit")),
+				api.WithApiKey(ctx.String("api-key")),
+			)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**Description**

This PR fixes #729 and #480

This PR adds `api-key` flag. When this flag is set, all API requests needs to provide the same value as Bear token in the request hear. If this flag is not set, no auth will be enabled. This flag is not set by default.  

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to LocalAI! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->