### PR TITLE
[build] pass build type to cmake on libtransformers.a build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ GPT4ALL_REPO?=https://github.com/nomic-ai/gpt4all
 GPT4ALL_VERSION?=d611d107479f3f5111f942c5e75ead9f2a3baca0
 
 # go-ggml-transformers version
-GOGGMLTRANSFORMERS_VERSION?=8e31841dcddca16468c11b2e7809f279fa76a832
+GOGGMLTRANSFORMERS_VERSION?=49159dd521bf882ec07b46980a5a94ae2776e291
 
 # go-rwkv version
 RWKV_REPO?=https://github.com/donomii/go-rwkv.cpp

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ GPT4ALL_REPO?=https://github.com/nomic-ai/gpt4all
 GPT4ALL_VERSION?=d611d107479f3f5111f942c5e75ead9f2a3baca0
 
 # go-ggml-transformers version
-GOGGMLTRANSFORMERS_VERSION?=49159dd521bf882ec07b46980a5a94ae2776e291
+GOGGMLTRANSFORMERS_VERSION?=ffb09d7dd71e2cbc6c5d7d05357d230eea6f369a
 
 # go-rwkv version
 RWKV_REPO?=https://github.com/donomii/go-rwkv.cpp

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ gpt4all/gpt4all-bindings/golang/libgpt4all.a: gpt4all
 
 ## CEREBRAS GPT
 go-ggml-transformers:
-	git clone --recurse-submodules https://github.com/go-skynet/go-ggml-transformers.cpp go-ggml-transformers
+	git clone --recurse-submodules https://github.com/hiventive/go-ggml-transformers.cpp go-ggml-transformers
 	cd go-ggml-transformers && git checkout -b build $(GOGPT2_VERSION) && git submodule update --init --recursive --depth 1
 	# This is hackish, but needed as both go-llama and go-gpt4allj have their own version of ggml..
 	@find ./go-ggml-transformers -type f -name "*.c" -exec sed -i'' -e 's/ggml_/ggml_gpt2_/g' {} +
@@ -213,7 +213,7 @@ go-ggml-transformers:
 	@find ./go-ggml-transformers -type f -name "*.h" -exec sed -i'' -e 's/clear_numa_thread_affinity/transformers_clear_numa_thread_affinity/g' {} +
 
 go-ggml-transformers/libtransformers.a: go-ggml-transformers
-	$(MAKE) -C go-ggml-transformers libtransformers.a
+	$(MAKE) -C go-ggml-transformers BUILD_TYPE=$(BUILD_TYPE) libtransformers.a
 
 whisper.cpp:
 	git clone https://github.com/ggerganov/whisper.cpp.git

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ gpt4all/gpt4all-bindings/golang/libgpt4all.a: gpt4all
 
 ## CEREBRAS GPT
 go-ggml-transformers:
-	git clone --recurse-submodules https://github.com/hiventive/go-ggml-transformers.cpp go-ggml-transformers
+	git clone --recurse-submodules https://github.com/go-skynet/go-ggml-transformers.cpp go-ggml-transformers
 	cd go-ggml-transformers && git checkout -b build $(GOGPT2_VERSION) && git submodule update --init --recursive --depth 1
 	# This is hackish, but needed as both go-llama and go-gpt4allj have their own version of ggml..
 	@find ./go-ggml-transformers -type f -name "*.c" -exec sed -i'' -e 's/ggml_/ggml_gpt2_/g' {} +


### PR DESCRIPTION
**Description**

This PR modifies the makefile so the build type is passed to cmake when building libtransformers.a.

**Notes for Reviewers**

Related to https://github.com/go-skynet/go-ggml-transformers.cpp/pull/40

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to LocalAI! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->