### PR TITLE
fix: make first stream message to send empty content

### DIFF
--- a/api/openai/chat.go
+++ b/api/openai/chat.go
@@ -19,9 +19,10 @@ import (
 
 func ChatEndpoint(cm *config.ConfigLoader, o *options.Option) func(c *fiber.Ctx) error {
 	process := func(s string, req *OpenAIRequest, config *config.Config, loader *model.ModelLoader, responses chan OpenAIResponse) {
+		emptyMessage := ""
 		initialMessage := OpenAIResponse{
 			Model:   req.Model, // we have to return what the user sent here, due to OpenAI spec.
-			Choices: []Choice{{Delta: &Message{Role: "assistant"}}},
+			Choices: []Choice{{Delta: &Message{Role: "assistant", Content: &emptyMessage}}},
 			Object:  "chat.completion.chunk",
 		}
 		responses <- initialMessage


### PR DESCRIPTION
Previously we were using omitempty which was then parsed by clients as "". Now we return null, which certain clients concatenates blindly.

This makes it close to OpenAI where the first message sent has an empty content, but just the role.

**Description**

This PR fixes
![Screenshot from 2023-07-15 22-49-48](https://github.com/go-skynet/LocalAI/assets/2420543/0c61e7b0-b534-4ce7-b035-38ab7c3c8ff7)

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to LocalAI! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->