### PR TITLE
feat: resolve JSONSchema refs (planners)

### DIFF
--- a/pkg/grammar/functions.go
+++ b/pkg/grammar/functions.go
@@ -18,9 +18,17 @@ func (f Functions) ToJSONStructure() JSONFunctionStructure {
 		//tt := t.(string)
 
 		properties := function.Parameters["properties"]
+		defs := function.Parameters["$defs"]
 		dat, _ := json.Marshal(properties)
+		dat2, _ := json.Marshal(defs)
 		prop := map[string]interface{}{}
+		defsD := map[string]interface{}{}
+
 		json.Unmarshal(dat, &prop)
+		json.Unmarshal(dat2, &defsD)
+		if js.Defs == nil {
+			js.Defs = defsD
+		}
 		js.OneOf = append(js.OneOf, Item{
 			Type: "object",
 			Properties: Properties{


### PR DESCRIPTION
**Description**

This PR adds compatibility to the JSONSchema notation `$defs` and `$refs` which allow to re-use objects across a schema.

This allows projects like  https://github.com/stillmatic/gollum or https://github.com/jxnl/openai_function_call compatible.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to LocalAI! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->