### PR TITLE
fix(config): "EnabelLowVRAM" typo

### DIFF
--- a/pkg/grpc/llm/llama/llama.go
+++ b/pkg/grpc/llm/llama/llama.go
@@ -60,7 +60,7 @@ func (llm *LLM) Load(opts *pb.ModelOptions) error {
 	}
 
 	if opts.LowVRAM {
-		llamaOpts = append(llamaOpts, llama.EnabelLowVRAM)
+		llamaOpts = append(llamaOpts, llama.EnableLowVRAM)
 	}
 
 	model, err := llama.New(opts.Model, llamaOpts...)


### PR DESCRIPTION
**Description**

This PR fixes something maybe?

**Notes for Reviewers**

IDK what I'm doing, I found this project yesterday, but I was having this problem:

1. I set `low_vram: true` in my model config .yaml. On server startup with debug logs enabled, my config would log correctly "LowVRAM:true" among my other settings (before the Fiber splash screen).
2. Then later when making my first request to the chat completions API I'd see this output:
  
  ![logs showing LowVRAM set to false](https://github.com/go-skynet/LocalAI/assets/1647792/e7c4b25b-7eac-4fcc-a26b-f48c4c864ab3)
3. So I started poking around and found that typo. Maybe that's why the config option isn't making it down where it needs to be?

Sorry if I didn't follow your PR rules or something, just wanted to make you aware of it.


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] IDK if I signed my commits.
 

<!--
Thank you for contributing to LocalAI! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
6. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->