### PR TITLE
refactor: Remove remaining uses of depreciated package `io/ioutil`

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -45,7 +44,7 @@ func getModelStatus(url string) (response map[string]interface{}) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Println("Error reading response body:", err)
 		return
@@ -97,7 +96,7 @@ func postModelApplyRequest(url string, request modelApplyRequest) (response map[
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Println("Error reading response body:", err)
 		return
@@ -153,7 +152,7 @@ var _ = Describe("API test", func() {
 			}
 			out, err := yaml.Marshal(g)
 			Expect(err).ToNot(HaveOccurred())
-			err = ioutil.WriteFile(filepath.Join(tmpdir, "gallery_simple.yaml"), out, 0644)
+			err = os.WriteFile(filepath.Join(tmpdir, "gallery_simple.yaml"), out, 0644)
 			Expect(err).ToNot(HaveOccurred())
 
 			galleries := []gallery.Gallery{

--- a/api/openai/image.go
+++ b/api/openai/image.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -105,7 +104,7 @@ func ImageEndpoint(cm *config.ConfigLoader, o *options.Option) func(c *fiber.Ctx
 					tempDir = o.ImageDir
 				}
 				// Create a temporary file
-				outputFile, err := ioutil.TempFile(tempDir, "b64")
+				outputFile, err := os.CreateTemp(tempDir, "b64")
 				if err != nil {
 					return err
 				}

--- a/pkg/gallery/models_test.go
+++ b/pkg/gallery/models_test.go
@@ -1,7 +1,6 @@
 package gallery_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -50,7 +49,7 @@ var _ = Describe("Model test", func() {
 			}}
 			out, err := yaml.Marshal(gallery)
 			Expect(err).ToNot(HaveOccurred())
-			err = ioutil.WriteFile(filepath.Join(tempdir, "gallery_simple.yaml"), out, 0644)
+			err = os.WriteFile(filepath.Join(tempdir, "gallery_simple.yaml"), out, 0644)
 			Expect(err).ToNot(HaveOccurred())
 
 			galleries := []Gallery{


### PR DESCRIPTION
https://pkg.go.dev/io/ioutil

my IDE tooling claims loudly that ioutil is depreciated, might as well just clean up the remaining uses now and switch to `io` and `os` since we already use those regularly.

Probably not a huge deal, but reduced warning pressure is reason enough for me to suggest this.