### PR TITLE
Create .gitattributes to force git clone to keep the LF line endings on .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
This change forces `git clone` to keep the LF line endings on .sh files

**Description**

This PR fixes https://www.reddit.com/r/AutoGPT/comments/1438fb6/localai_v1180_release/ 

where cloning the repository onto a windows machine changes the line-endings of .sh files to CRLF, breaking them.
