### PR TITLE
feat: "simple" chat/edit/completion template system prompt from config

### DIFF
--- a/api/openai/chat.go
+++ b/api/openai/chat.go
@@ -207,8 +207,9 @@ func ChatEndpoint(cm *config.ConfigLoader, o *options.Option) func(c *fiber.Ctx)
 
 		// A model can have a "file.bin.tmpl" file associated with a prompt template prefix
 		templatedInput, err := o.Loader.EvaluateTemplateForPrompt(model.ChatPromptTemplate, templateFile, model.PromptTemplateData{
-			Input:     predInput,
-			Functions: funcs,
+			SystemPrompt: config.SystemPrompt,
+			Input:        predInput,
+			Functions:    funcs,
 		})
 		if err == nil {
 			predInput = templatedInput

--- a/api/openai/chat.go
+++ b/api/openai/chat.go
@@ -109,6 +109,7 @@ func ChatEndpoint(cm *config.ConfigLoader, o *options.Option) func(c *fiber.Ctx)
 
 		var predInput string
 
+		suppressConfigSystemPrompt := false
 		mess := []string{}
 		for messageIndex, i := range input.Messages {
 			var content string
@@ -146,7 +147,7 @@ func ChatEndpoint(cm *config.ConfigLoader, o *options.Option) func(c *fiber.Ctx)
 					content = templatedChatMessage
 				}
 			}
-			// If this model doesn't have such a template, or if
+			// If this model doesn't have such a template, or if that template fails to return a value, template at the message level.
 			if content == "" {
 				if r != "" {
 					if contentExists {
@@ -176,6 +177,10 @@ func ChatEndpoint(cm *config.ConfigLoader, o *options.Option) func(c *fiber.Ctx)
 							}
 						}
 					}
+				}
+				// Special Handling: System. We care if it was printed at all, not the r branch, so check seperately
+				if contentExists && role == "system" {
+					suppressConfigSystemPrompt = true
 				}
 			}
 
@@ -207,9 +212,10 @@ func ChatEndpoint(cm *config.ConfigLoader, o *options.Option) func(c *fiber.Ctx)
 
 		// A model can have a "file.bin.tmpl" file associated with a prompt template prefix
 		templatedInput, err := o.Loader.EvaluateTemplateForPrompt(model.ChatPromptTemplate, templateFile, model.PromptTemplateData{
-			SystemPrompt: config.SystemPrompt,
-			Input:        predInput,
-			Functions:    funcs,
+			SystemPrompt:         config.SystemPrompt,
+			SuppressSystemPrompt: suppressConfigSystemPrompt,
+			Input:                predInput,
+			Functions:            funcs,
 		})
 		if err == nil {
 			predInput = templatedInput

--- a/api/openai/completion.go
+++ b/api/openai/completion.go
@@ -123,7 +123,8 @@ func CompletionEndpoint(cm *config.ConfigLoader, o *options.Option) func(c *fibe
 		for k, i := range config.PromptStrings {
 			// A model can have a "file.bin.tmpl" file associated with a prompt template prefix
 			templatedInput, err := o.Loader.EvaluateTemplateForPrompt(model.CompletionPromptTemplate, templateFile, model.PromptTemplateData{
-				Input: i,
+				SystemPrompt: config.SystemPrompt,
+				Input:        i,
 			})
 			if err == nil {
 				i = templatedInput

--- a/api/openai/edit.go
+++ b/api/openai/edit.go
@@ -35,8 +35,9 @@ func EditEndpoint(cm *config.ConfigLoader, o *options.Option) func(c *fiber.Ctx)
 		for _, i := range config.InputStrings {
 			// A model can have a "file.bin.tmpl" file associated with a prompt template prefix
 			templatedInput, err := o.Loader.EvaluateTemplateForPrompt(model.EditPromptTemplate, templateFile, model.PromptTemplateData{
-				Input:       i,
-				Instruction: input.Instruction,
+				Input:        i,
+				Instruction:  input.Instruction,
+				SystemPrompt: config.SystemPrompt,
 			})
 			if err == nil {
 				i = templatedInput

--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -20,6 +20,7 @@ import (
 // These are the definitions of all possible variables LocalAI will currently populate for use in a prompt template file
 // Please note: Not all of these are populated on every endpoint - your template should either be tested for each endpoint you map it to, or tolerant of zero values.
 type PromptTemplateData struct {
+	SystemPrompt string
 	Input        string
 	Instruction  string
 	Functions    []grammar.Function

--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -20,11 +20,12 @@ import (
 // These are the definitions of all possible variables LocalAI will currently populate for use in a prompt template file
 // Please note: Not all of these are populated on every endpoint - your template should either be tested for each endpoint you map it to, or tolerant of zero values.
 type PromptTemplateData struct {
-	SystemPrompt string
-	Input        string
-	Instruction  string
-	Functions    []grammar.Function
-	MessageIndex int
+	SystemPrompt         string
+	SuppressSystemPrompt bool // used by chat specifically to indicate that SystemPrompt above should be _ignored_
+	Input                string
+	Instruction          string
+	Functions            []grammar.Function
+	MessageIndex         int
 }
 
 // TODO: Ask mudler about FunctionCall stuff being useful at the message level?


### PR DESCRIPTION
**Description**
 Model configuration already allowed for the concept of a per-configuration "default system prompt", but it only functioned for the `chat-message` endpoint. This PR adds two related template variables for `*.tmpl` authors to use, specifically for the "simpler" `chat` / `edit` / `completion` templates.

- `SystemPrompt`: string - is configured as `system_prompt` in the model yaml configuration file. Intended to serve as a default system prompt for this model configuration, especially if nothing else is specified (such as a `messages` array without a leading system element, or a completion request where there's no real place for it) 
- `SupressSystemPrompt`: bool - is a template utility and only can ever be true in the `chat` endpoint currently. If a message with `role == system` was seen (and presumably used in the .Input template variable somehow) , this variable will become true. This is intended to make it easy to _not_ include {{ .SystemPrompt }}in your template in that case!
    - (Side note: if your prompt should have a custom system prompt per-request, and it doesn't belong in .Input, it's time to graduate to the `chat-message` template)

Note: Currently absolutely no templates use these variables! But the plan is to modify the standard vicuna style prompt to be something like:

```
{{if not .SuppressSystemPrompt}}{{.SystemPrompt}}{{end}}
### Instruction:
{{.Input}}

### Response:
```


... but it's late and I'll test that part tomorrow. Creating this PR to get the variables reviewed first, since worst case they do nothing.