### PR TITLE
fix: do not break on newlines on function returns

### DIFF
--- a/api/openai/chat.go
+++ b/api/openai/chat.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-skynet/LocalAI/api/options"
 	"github.com/go-skynet/LocalAI/pkg/grammar"
 	model "github.com/go-skynet/LocalAI/pkg/model"
+	"github.com/go-skynet/LocalAI/pkg/utils"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/valyala/fasthttp"
@@ -274,6 +275,8 @@ func ChatEndpoint(cm *config.ConfigLoader, o *options.Option) func(c *fiber.Ctx)
 			if processFunctions {
 				// As we have to change the result before processing, we can't stream the answer (yet?)
 				ss := map[string]interface{}{}
+				// This prevent newlines to break JSON parsing for clients
+				s = utils.EscapeNewLines(s)
 				json.Unmarshal([]byte(s), &ss)
 				log.Debug().Msgf("Function return: %s %+v", s, ss)
 

--- a/pkg/utils/json.go
+++ b/pkg/utils/json.go
@@ -1,0 +1,13 @@
+package utils
+
+import "regexp"
+
+var matchNewlines = regexp.MustCompile(`[\r\n]`)
+
+const doubleQuote = `"[^"\\]*(?:\\[\s\S][^"\\]*)*"`
+
+func EscapeNewLines(s string) string {
+	return regexp.MustCompile(doubleQuote).ReplaceAllStringFunc(s, func(s string) string {
+		return matchNewlines.ReplaceAllString(s, "\\n")
+	})
+}


### PR DESCRIPTION
**Description**

This is a guard from the model returning newlines which are not allowed in JSON - as such we escape them with `\\n`

**Notes for Reviewers**

Since https://github.com/go-skynet/LocalAI/pull/862 now strings contains newlines, and as such JSON can output multi-line text as well now.