### PR TITLE
fix: disable usage by default (still experimental)

### DIFF
--- a/api/backend/llm.go
+++ b/api/backend/llm.go
@@ -74,8 +74,9 @@ func ModelInference(ctx context.Context, s string, loader *model.ModelLoader, c 
 
 		tokenUsage := TokenUsage{}
 
-		// check the per-model feature flag for usage, since tokenCallback may have a cost, but default to on.
-		if !c.FeatureFlag["usage"] {
+		// check the per-model feature flag for usage, since tokenCallback may have a cost.
+		// Defaults to off as for now it is still experimental
+		if c.FeatureFlag.Enabled("usage") {
 			userTokenCallback := tokenCallback
 			if userTokenCallback == nil {
 				userTokenCallback = func(token string, usage TokenUsage) bool {

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -29,7 +29,7 @@ type Config struct {
 
 	FunctionsConfig Functions `yaml:"function"`
 
-	FeatureFlag map[string]bool `yaml:"feature_flags"` // Feature Flag registry. We move fast, and features may break on a per model/backend basis. Registry for (usually temporary) flags that indicate aborting something early.
+	FeatureFlag FeatureFlag `yaml:"feature_flags"` // Feature Flag registry. We move fast, and features may break on a per model/backend basis. Registry for (usually temporary) flags that indicate aborting something early.
 	// LLM configs (GPT4ALL, Llama.cpp, ...)
 	LLMConfig `yaml:",inline"`
 
@@ -43,6 +43,13 @@ type Config struct {
 
 	// GRPC Options
 	GRPC GRPC `yaml:"grpc"`
+}
+
+type FeatureFlag map[string]*bool
+
+func (ff FeatureFlag) Enabled(s string) bool {
+	v, exist := ff[s]
+	return exist && v != nil && *v
 }
 
 type GRPC struct {


### PR DESCRIPTION
**Description**

This PR makes `usage` turned off by default and make it opt-in. Let's promote it to default when it had sufficient rounds of testing.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to LocalAI! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->