### PR TITLE
infra: add setup-go@4, test against 1.20.x (go.mod) and stable (1.21)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,21 @@ concurrency:
 jobs:
   ubuntu-latest:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        go-version: ['1.20.x', 'stable']
     steps:
       - name: Clone
         uses: actions/checkout@v3
         with: 
           submodules: true
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      # You can test your matrix by printing the current Go version
+      - name: Display Go version
+        run: go version
       - name: Dependencies
         run: |
           sudo apt-get update
@@ -52,13 +61,21 @@ jobs:
 
   macOS-latest:
     runs-on: macOS-latest
-
+    strategy:
+      matrix:
+        go-version: ['1.20.x', 'stable']
     steps:
       - name: Clone
         uses: actions/checkout@v3
         with: 
           submodules: true
-
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      # You can test your matrix by printing the current Go version
+      - name: Display Go version
+        run: go version
       - name: Test
         run: |
           CMAKE_ARGS="-DLLAMA_F16C=OFF -DLLAMA_AVX512=OFF -DLLAMA_AVX2=OFF -DLLAMA_FMA=OFF" make test


### PR DESCRIPTION
Small infra PR to introduce the setup-go action. Very similar to what was done in https://github.com/go-skynet/go-llama.cpp/pull/177, but slightly modified to fit the different pipeline

Currently tests against 1.20.x and stable (1.21.0 at time of writing).