### PR TITLE
feat: backend monitor shutdown endpoint, process based

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -218,6 +218,7 @@ func App(opts ...options.AppOption) (*fiber.App, error) {
 	// Experimental Backend Statistics Module
 	backendMonitor := localai.NewBackendMonitor(cl, options) // Split out for now
 	app.Get("/backend/monitor", localai.BackendMonitorEndpoint(backendMonitor))
+	app.Post("/backend/shutdown", localai.BackendShutdownEndpoint(backendMonitor))
 
 	// models
 	app.Get("/v1/models", auth, openai.ListModelsEndpoint(options.Loader, cl))

--- a/api/localai/backend_monitor.go
+++ b/api/localai/backend_monitor.go
@@ -158,6 +158,6 @@ func BackendShutdownEndpoint(bm BackendMonitor) func(c *fiber.Ctx) error {
 			return err
 		}
 
-		return bm.options.Loader.UnloadModel(backendId)
+		return bm.options.Loader.ShutdownModel(backendId)
 	}
 }

--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -128,6 +128,17 @@ func (ml *ModelLoader) LoadModel(modelName string, loader func(string, string) (
 	return model, nil
 }
 
+func (ml *ModelLoader) UnloadModel(modelName string) error {
+	ml.mu.Lock()
+	defer ml.mu.Unlock()
+	if _, ok := ml.models[modelName]; !ok {
+		return fmt.Errorf("model %s not found", modelName)
+	}
+
+	delete(ml.models, modelName)
+	return ml.deleteProcess(modelName)
+}
+
 func (ml *ModelLoader) CheckIsLoaded(s string) *grpc.Client {
 	if m, ok := ml.models[s]; ok {
 		log.Debug().Msgf("Model already loaded in memory: %s", s)

--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -128,14 +128,13 @@ func (ml *ModelLoader) LoadModel(modelName string, loader func(string, string) (
 	return model, nil
 }
 
-func (ml *ModelLoader) UnloadModel(modelName string) error {
+func (ml *ModelLoader) ShutdownModel(modelName string) error {
 	ml.mu.Lock()
 	defer ml.mu.Unlock()
 	if _, ok := ml.models[modelName]; !ok {
 		return fmt.Errorf("model %s not found", modelName)
 	}
 
-	delete(ml.models, modelName)
 	return ml.deleteProcess(modelName)
 }
 


### PR DESCRIPTION
This PR adds a new endpoint to the backend monitor section `/backend/shutdown` which terminates the grpc process for the related model.