### PR TITLE
 Allow to manually set the seed for the SD pipeline

### DIFF
--- a/extra/grpc/diffusers/backend_diffusers.py
+++ b/extra/grpc/diffusers/backend_diffusers.py
@@ -300,6 +300,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             "width":               request.width, 
             "height":              request.height,
             "num_inference_steps": request.step,
+            "seed":                request.seed,
         }
 
         if request.src != "":
@@ -317,6 +318,12 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
 
         # create a dictionary of parameters by using the keys from EnableParameters and the values from defaults
         kwargs = {key: options[key] for key in keys}
+
+        # Set seed
+        if request.seed > 0:
+            kwargs["generator"] = torch.Generator(device="cuda").manual_seed(
+                request.seed
+            )
 
         image = {}
         if COMPEL:


### PR DESCRIPTION
**Description**

Enable setting the seed for the stable diffusion pipeline. This is done through an additional `seed` parameter in the request, such as:

```bash
curl http://localhost:8080/v1/images/generations \
    -H "Content-Type: application/json" \
    -d '{"model": "stablediffusion", "prompt": "prompt", "n": 1, "step": 51, "size": "512x512", "seed": 3}'
```

**Notes for Reviewers**
When the `seed` parameter is not sent, `request.seed` defaults to `0`, making it difficult to detect an actual seed of `0`. Is there a way to change the default to `-1` for instance ?

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to LocalAI! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->