### PR TITLE
[query_data example] max_chunk_overlap in PromptHelper must be in 0..1 range

### DIFF
--- a/examples/query_data/query.py
+++ b/examples/query_data/query.py
@@ -15,7 +15,7 @@ llm_predictor = LLMPredictor(llm=OpenAI(temperature=0, model_name="gpt-3.5-turbo
 # Configure prompt parameters and initialise helper
 max_input_size = 500
 num_output = 256
-max_chunk_overlap = 20
+max_chunk_overlap = 0.2
 
 prompt_helper = PromptHelper(max_input_size, num_output, max_chunk_overlap)
 

--- a/examples/query_data/store.py
+++ b/examples/query_data/store.py
@@ -15,7 +15,7 @@ llm_predictor = LLMPredictor(llm=OpenAI(temperature=0, model_name="gpt-3.5-turbo
 # Configure prompt parameters and initialise helper
 max_input_size = 400
 num_output = 400
-max_chunk_overlap = 30
+max_chunk_overlap = 0.3
 
 prompt_helper = PromptHelper(max_input_size, num_output, max_chunk_overlap)
 


### PR DESCRIPTION
**Description**

Simple fix, percentage value is expected to be float in range 0..1

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to LocalAI! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->