### PR TITLE
Update README to reflect changes in Continue's config file

### DIFF
--- a/examples/continue/README.md
+++ b/examples/continue/README.md
@@ -28,7 +28,7 @@ For a live demonstration, please click on the link below:
 3. Type `/config` within Continue's VSCode extension, or edit the file located at `~/.continue/config.py` on your system with the following configuration:
 
     ```py
-    from continuedev.src.continuedev.libs.llm.openai import OpenAI, OpenAIServerInfo
+    from continuedev.src.continuedev.libs.llm.openai import OpenAI
 
     config = ContinueConfig(
        ...
@@ -36,10 +36,7 @@ For a live demonstration, please click on the link below:
             default=OpenAI(
                api_key="my-api-key",
                model="gpt-3.5-turbo",
-               openai_server_info=OpenAIServerInfo(
-                  api_base="http://localhost:8080",
-                  model="gpt-3.5-turbo"
-               )
+               api_base="http://localhost:8080",
             )
        ),
     )


### PR DESCRIPTION
**Description**

OpenAIServerInfo no longer exists, and api_base has been moved up. Changes were made here https://github.com/continuedev/continue/commit/8967e2d53f4f6ff744c408ae1042caffb25627f9#diff-98e147eaa7c9936befdddabb16c72447fbf8ad2df6b680c5176c24813169858e