### PR TITLE
Exposing DEBUG env var for docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,5 +13,4 @@ services:
     volumes:
       - ./models:/models:cached
     command: ["/usr/bin/local-ai" ]
-    environment:
-      - DEBUG
+    environment: []  # Use .env file

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,3 +13,5 @@ services:
     volumes:
       - ./models:/models:cached
     command: ["/usr/bin/local-ai" ]
+    environment:
+      - DEBUG


### PR DESCRIPTION
Coming from https://github.com/go-skynet/LocalAI/issues/1069, this enables users to: `DEBUG=true docker-compose up`

SEE: https://docs.docker.com/compose/environment-variables/set-environment-variables/#use-the-environment-attribute