### PR TITLE
feat(conda):Add seperate conda env for exllama

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 
 ENV BUILD_TYPE=${BUILD_TYPE}
-ENV EXTERNAL_GRPC_BACKENDS="huggingface-embeddings:/build/extra/grpc/huggingface/run.sh,autogptq:/build/extra/grpc/autogptq/run.sh,bark:/build/extra/grpc/bark/run.sh,diffusers:/build/extra/grpc/diffusers/run.sh,exllama:/build/extra/grpc/exllama/exllama.py,vall-e-x:/build/extra/grpc/vall-e-x/run.sh,vllm:/build/extra/grpc/vllm/run.sh"
+ENV EXTERNAL_GRPC_BACKENDS="huggingface-embeddings:/build/extra/grpc/huggingface/run.sh,autogptq:/build/extra/grpc/autogptq/run.sh,bark:/build/extra/grpc/bark/run.sh,diffusers:/build/extra/grpc/diffusers/run.sh,exllama:/build/extra/grpc/exllama/run.sh,vall-e-x:/build/extra/grpc/vall-e-x/run.sh,vllm:/build/extra/grpc/vllm/run.sh"
 ENV GALLERIES='[{"name":"model-gallery", "url":"github:go-skynet/model-gallery/index.yaml"}, {"url": "github:go-skynet/model-gallery/huggingface.yaml","name":"huggingface"}]'
 ARG GO_TAGS="stablediffusion tts"
 

--- a/Makefile
+++ b/Makefile
@@ -416,6 +416,7 @@ prepare-extra-conda-environments:
 	$(MAKE) -C extra/grpc/vllm
 	$(MAKE) -C extra/grpc/huggingface
 	$(MAKE) -C extra/grpc/vall-e-x
+	$(MAKE) -C extra/grpc/exllama
 
 
 backend-assets/grpc:

--- a/extra/grpc/exllama/Makefile
+++ b/extra/grpc/exllama/Makefile
@@ -1,0 +1,11 @@
+.PONY: exllama
+exllama:
+	@echo "Creating virtual environment..."
+	@conda env create --name exllama --file exllama.yml
+	@echo "Virtual environment created."
+
+.PONY: run
+run:
+	@echo "Running exllama..."
+	bash run.sh
+	@echo "exllama run."

--- a/extra/grpc/exllama/README.md
+++ b/extra/grpc/exllama/README.md
@@ -1,0 +1,5 @@
+# Creating a separate environment for the exllama project
+
+```
+make exllama
+```

--- a/extra/grpc/exllama/exllama.yml
+++ b/extra/grpc/exllama/exllama.yml
@@ -1,0 +1,55 @@
+name: exllama
+channels:
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1=main
+  - _openmp_mutex=5.1=1_gnu
+  - bzip2=1.0.8=h7b6447c_0
+  - ca-certificates=2023.08.22=h06a4308_0
+  - ld_impl_linux-64=2.38=h1181459_1
+  - libffi=3.4.4=h6a678d5_0
+  - libgcc-ng=11.2.0=h1234567_1
+  - libgomp=11.2.0=h1234567_1
+  - libstdcxx-ng=11.2.0=h1234567_1
+  - libuuid=1.41.5=h5eee18b_0
+  - ncurses=6.4=h6a678d5_0
+  - openssl=3.0.11=h7f8727e_2
+  - pip=23.2.1=py311h06a4308_0
+  - python=3.11.5=h955ad1f_0
+  - readline=8.2=h5eee18b_0
+  - setuptools=68.0.0=py311h06a4308_0
+  - sqlite=3.41.2=h5eee18b_0
+  - tk=8.6.12=h1ccaba5_0
+  - tzdata=2023c=h04d1e81_0
+  - wheel=0.41.2=py311h06a4308_0
+  - xz=5.4.2=h5eee18b_0
+  - zlib=1.2.13=h5eee18b_0
+  - pip:
+      - filelock==3.12.4
+      - fsspec==2023.9.2
+      - grpcio==1.59.0
+      - jinja2==3.1.2
+      - markupsafe==2.1.3
+      - mpmath==1.3.0
+      - networkx==3.1
+      - ninja==1.11.1
+      - nvidia-cublas-cu12==12.1.3.1
+      - nvidia-cuda-cupti-cu12==12.1.105
+      - nvidia-cuda-nvrtc-cu12==12.1.105
+      - nvidia-cuda-runtime-cu12==12.1.105
+      - nvidia-cudnn-cu12==8.9.2.26
+      - nvidia-cufft-cu12==11.0.2.54
+      - nvidia-curand-cu12==10.3.2.106
+      - nvidia-cusolver-cu12==11.4.5.107
+      - nvidia-cusparse-cu12==12.1.0.106
+      - nvidia-nccl-cu12==2.18.1
+      - nvidia-nvjitlink-cu12==12.2.140
+      - nvidia-nvtx-cu12==12.1.105
+      - protobuf==4.24.4
+      - safetensors==0.3.2
+      - sentencepiece==0.1.99
+      - sympy==1.12
+      - torch==2.1.0
+      - triton==2.1.0
+      - typing-extensions==4.8.0
+prefix: /opt/conda/envs/exllama

--- a/extra/grpc/exllama/run.sh
+++ b/extra/grpc/exllama/run.sh
@@ -1,0 +1,10 @@
+##
+## A bash script wrapper that runs the exllama server with conda
+
+# Activate conda environment
+source activate exllama
+
+# get the directory where the bash script is located
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+python $DIR/exllama.py


### PR DESCRIPTION
**Description**

This PR is related to #1117 

**Notes for Reviewers**
This PR follow the install process from https://github.com/jllllll/exllama#this-is-a-python-module-version-of-exllama

All the requirements were installed successfully. Also include (`grpcio` and `protobuf`).
* `torch==2.1.0`
* `safetensors==0.3.2`
* `sentencepiece==0.1.99`
* `ninja==1.11.1`

The `exllama` package was failed to install due to `CUDA_HOME environment variable is not set.` I do not have it in my environment(whatever the software or the hardware). So, I believe  I need some help in here.

```
(exllama) @Aisuko ➜ /workspaces/LocalAI (feat/exllama) $ python -m pip install git+https://github.com/jllllll/exllama
Collecting git+https://github.com/jllllll/exllama
  Cloning https://github.com/jllllll/exllama to /tmp/pip-req-build-tk7ebjcm
  Running command git clone --filter=blob:none --quiet https://github.com/jllllll/exllama /tmp/pip-req-build-tk7ebjcm
  Resolved https://github.com/jllllll/exllama to commit 982d33068f260e46e08fc76a0cde7c941b547bd1
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [16 lines of output]
      /opt/conda/envs/exllama/lib/python3.11/site-packages/torch/nn/modules/transformer.py:20: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at ../torch/csrc/utils/tensor_numpy.cpp:84.)
        device: torch.device = torch.device(torch._C._get_default_device()),  # torch.device('cpu'),
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-req-build-tk7ebjcm/setup.py", line 35, in <module>
          cpp_extension.CUDAExtension(
        File "/opt/conda/envs/exllama/lib/python3.11/site-packages/torch/utils/cpp_extension.py", line 1076, in CUDAExtension
          library_dirs += library_paths(cuda=True)
                          ^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/conda/envs/exllama/lib/python3.11/site-packages/torch/utils/cpp_extension.py", line 1203, in library_paths
          if (not os.path.exists(_join_cuda_home(lib_dir)) and
                                 ^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/conda/envs/exllama/lib/python3.11/site-packages/torch/utils/cpp_extension.py", line 2416, in _join_cuda_home
          raise OSError('CUDA_HOME environment variable is not set. '
      OSError: CUDA_HOME environment variable is not set. Please set it to your CUDA install root.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```


The others are same to other PRs.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->