### PR TITLE
Fix backend/cpp/llama CMakeList.txt on OSX 

### DIFF
--- a/backend/cpp/llama/CMakeLists.txt
+++ b/backend/cpp/llama/CMakeLists.txt
@@ -4,6 +4,11 @@ set(TARGET grpc-server)
 set(_PROTOBUF_LIBPROTOBUF libprotobuf)
 set(_REFLECTION grpc++_reflection)
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    link_directories("/opt/homebrew/lib")
+    include_directories("/opt/homebrew/include")
+endif()
+
 find_package(absl CONFIG REQUIRED)
 find_package(Protobuf CONFIG REQUIRED)
 find_package(gRPC CONFIG REQUIRED)
@@ -15,8 +20,7 @@ find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${Protobuf_INCLUDE_DIRS})
 
-message(STATUS "Using protobuf ${Protobuf_VERSION} ${Protobuf_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR}")
-
+message(STATUS "Using protobuf version ${Protobuf_VERSION} | Protobuf_INCLUDE_DIRS: ${Protobuf_INCLUDE_DIRS} | CMAKE_CURRENT_BINARY_DIR: ${CMAKE_CURRENT_BINARY_DIR}")
 
 # Proto file
 get_filename_component(hw_proto "../../../../../../pkg/grpc/proto/backend.proto" ABSOLUTE)

--- a/pkg/gallery/gallery.go
+++ b/pkg/gallery/gallery.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-skynet/LocalAI/pkg/utils"
 	"github.com/imdario/mergo"
+	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v2"
 )
 
@@ -166,7 +167,9 @@ func getGalleryModels(gallery Gallery, basePath string) ([]*GalleryModel, error)
 		return yaml.Unmarshal(d, &models)
 	})
 	if err != nil {
-
+		if yamlErr, ok := err.(*yaml.TypeError); ok {
+			log.Debug().Msgf("YAML errors: %s", strings.Join(yamlErr.Errors, "\n"))
+		}
 		return models, err
 	}
 

--- a/pkg/gallery/gallery.go
+++ b/pkg/gallery/gallery.go
@@ -168,7 +168,7 @@ func getGalleryModels(gallery Gallery, basePath string) ([]*GalleryModel, error)
 	})
 	if err != nil {
 		if yamlErr, ok := err.(*yaml.TypeError); ok {
-			log.Debug().Msgf("YAML errors: %s", strings.Join(yamlErr.Errors, "\n"))
+			log.Debug().Msgf("YAML errors: %s\n\nwreckage of models: %+v", strings.Join(yamlErr.Errors, "\n"), models)
 		}
 		return models, err
 	}


### PR DESCRIPTION
- detect OSX and use the directories associated with homebrew-installed libraries
- Tiny logging change makes it easier to detect Protobuf issues, was helpful while creating this so I'm keeping it in place